### PR TITLE
feat: add provider registry and sats4ai translation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Expected production URL:
 
 ## Workflow notes and planning
 
-- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, wallet setup notes, and live paid-test summary
+- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, wallet setup notes, live paid-test summary, and registry implementation notes
 - `docs/provider-tests/sats4ai-translate-text-2026-04-19.md` — first successful end-to-end paid endpoint test record for Sats4AI translation
 
 ## What still needs to be done

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Expected production URL:
 
 ## Workflow notes and planning
 
-- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, and wallet setup notes for the first live test
+- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, wallet setup notes, and live paid-test summary
+- `docs/provider-tests/sats4ai-translate-text-2026-04-19.md` — first successful end-to-end paid endpoint test record for Sats4AI translation
 
 ## What still needs to be done
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Expected production URL:
 └── README.md
 ```
 
+## Workflow notes and planning
+
+- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, and wallet setup notes for the first live test
+
 ## What still needs to be done
 
 In my opinion, the next useful steps are:

--- a/docs/provider-intake-and-activation.md
+++ b/docs/provider-intake-and-activation.md
@@ -277,6 +277,11 @@ Recommended first activation endpoint:
 - `translate-text`
 - `https://sats4ai.com/api/l402/translate-text`
 
+Status:
+
+- **paid test completed successfully**
+- detailed test record: `docs/provider-tests/sats4ai-translate-text-2026-04-19.md`
+
 Why:
 
 - cheap
@@ -289,6 +294,23 @@ Fallback candidates:
 
 - `generate-text`
 - `convert-html-to-pdf`
+
+### Live paid test result
+The first end-to-end paid test for Sats4AI has now been completed successfully.
+
+Summary:
+
+- tool used: `@getalby/cli fetch`
+- endpoint tested: `translate-text`
+- request succeeded end-to-end with real payment and retry
+- returned translated Spanish text successfully
+- service cost observed: `1 sat`
+- routing / payment fees observed: `1 sat`
+- total wallet delta observed: `2 sats`
+
+See full artifact record:
+
+- `docs/provider-tests/sats4ai-translate-text-2026-04-19.md`
 
 ### Why `translate-text` is preferred over `generate-text`
 `generate-text` works, but translation is more differentiated and makes a better first landing-page story for a pay-per-use service.

--- a/docs/provider-intake-and-activation.md
+++ b/docs/provider-intake-and-activation.md
@@ -1,0 +1,357 @@
+# Provider Intake and Activation Workflow
+
+> Working notes for the 402 landing pages project. This document records the current manual test flow so we can formalize it into a repeatable provider registry + activation workflow later.
+
+**Last updated:** 2026-04-19T08:16:35Z  
+**Discovery scope for v1:** `402index.io` only
+
+---
+
+## Why this document exists
+
+We need a scalable way to grow the landing pages catalog when 402index contains thousands of endpoints and many providers have very large service catalogs.
+
+The key decision is:
+
+- evaluate **providers first**
+- only activate **a few endpoints per approved provider** at first
+- test the real payment flow before generating landing pages
+- record decisions in git so we do not re-evaluate the same provider repeatedly
+
+This file captures the agreed manual workflow and the first live test case.
+
+---
+
+## Current design decisions
+
+### Discovery source
+For now we only use:
+
+- `402index.io`
+
+We are **not** scanning Satring, Sponge, x402 Bazaar directly, or other registries yet.
+
+### Control plane
+We want a provider registry in the repo that records whether a provider is:
+
+- approved
+- rejected
+- deferred
+- duplicate
+- already activated/live
+
+### Existing providers
+Providers already live in landing pages should be backfilled into the future registry as lightweight legacy entries, not re-reviewed from scratch.
+
+Suggested legacy metadata shape:
+
+- `reviewStatus: approved`
+- `reviewSource: legacy-manual`
+- `activationStatus: live`
+- `backfilled: true`
+
+### Workflow split
+We want two distinct workflows:
+
+1. **Provider intake / evaluation**
+   - discover provider
+   - dedupe against repo + open PRs
+   - evaluate credibility
+   - record decision in git
+
+2. **Provider activation**
+   - choose 1–3 cheap / interesting endpoints
+   - run a real paid test
+   - capture outputs / artifacts
+   - generate landing-page data
+
+---
+
+## Proposed future repository structure
+
+Not implemented yet, but this is the current direction.
+
+```text
+registry/
+  providers/
+    <provider>.yaml
+  provider-endpoint-candidates/
+    <provider>.yaml
+
+docs/
+  provider-evaluations/
+    <provider>.md
+  provider-intake-and-activation.md
+```
+
+Rationale:
+
+- `registry/providers/*` = machine-readable provider state
+- `docs/provider-evaluations/*` = human-readable review notes and evidence
+- `src/data/providers/*` and `src/data/services/*` remain the already-activated landing-page source of truth
+
+### Provider registry should eventually record
+
+- canonical provider key
+- provider name
+- website URL
+- protocol(s)
+- source indexes
+- first seen / last reviewed dates
+- decision status
+- activation status
+- duplicate-of link if relevant
+- concise decision summary
+- notes / links / docs / GitHub
+
+---
+
+## Manual v1 workflow
+
+### Step 1 — Discover provider from 402index
+- Search provider name on 402index
+- Confirm there are indexed services/endpoints
+- Note health, protocol, category, price, and source metadata from the index
+
+### Step 2 — Dedupe before opening any PR
+Check for existing references in:
+
+- repo content
+- existing provider registry entries (future)
+- open GitHub PRs
+- closed GitHub PRs if needed
+
+Canonical dedupe should use the provider / brand / root domain, not individual endpoint paths.
+
+### Step 3 — Evaluate provider credibility
+Check:
+
+- website quality
+- docs quality
+- pricing clarity
+- terms / contact / support
+- GitHub repos
+- whether the provider exposes real discovery docs
+- whether the endpoints issue valid payment challenges
+- any obvious red flags
+
+### Step 4 — Decide provider status
+Recommended status buckets:
+
+- `approved`
+- `approved-for-trial`
+- `deferred`
+- `rejected`
+- `duplicate`
+
+### Step 5 — Choose only a few endpoints initially
+Selection criteria:
+
+- cheap to test
+- clear user value
+- simple request / response shape
+- strong landing-page story
+- synchronous when possible
+
+Avoid initial activation of expensive, obscure, or highly async endpoints unless necessary.
+
+### Step 6 — Run a real paid test
+For an approved provider:
+
+- trigger the 402 / L402 challenge
+- pay it
+- retry successfully
+- save request / response / output artifacts
+- record quirks and pricing
+
+### Step 7 — Only then generate landing page data
+Once the test is real and documented:
+
+- add provider data if needed
+- add service data
+- add any captured output asset
+- create landing page PR
+
+---
+
+## Sats4AI manual test case
+
+### Why Sats4AI was chosen
+Sats4AI is the first manual provider used to validate the workflow.
+
+### Duplicate check results
+Checked on 2026-04-19:
+
+- no `Sats4AI` / `sats4ai` references in the repo
+- no open GitHub PRs matching `Sats4AI`
+- no historical GitHub PRs matching `Sats4AI`
+
+Conclusion:
+
+- clean candidate for first provider intake test
+
+### 402index findings
+402index search returned about 30 Sats4AI services, including:
+
+- `generate-text`
+- `translate-text`
+- `transcribe-audio`
+- `extract-document`
+- `convert-html-to-pdf`
+- `generate-image`
+- `analyze-image`
+
+402index currently marks many Sats4AI services as:
+
+- protocol: `L402`
+- provider: `Sats4AI`
+- status: `down`
+- poor reliability / uptime
+- source often includes `self-registered`
+
+Important observation:
+
+- 402index health did **not** fully match direct provider behavior
+
+### Direct provider evidence gathered
+Checked directly on `https://sats4ai.com`:
+
+- homepage exists and is product-specific
+- L402 docs exist: `/l402`
+- MCP docs exist: `/mcp`
+- unified docs exist: `/docs`
+- terms exist: `/terms`
+- contact page exists: `/contact`
+- roadmap exists: `/roadmap`
+- machine-readable discovery exists:
+  - `/.well-known/l402-services`
+  - `/llms.txt`
+- public GitHub links exposed in docs:
+  - `cnghockey/sats4ai-mcp-server`
+  - `cnghockey/sats4ai-l402-examples`
+
+### L402 verification results
+Direct terminal probes showed valid L402 challenge responses from real endpoints, including:
+
+- `https://sats4ai.com/api/l402/generate-text`
+- `https://sats4ai.com/api/l402/translate-text`
+- `https://sats4ai.com/api/l402/convert-html-to-pdf`
+
+Observed behavior:
+
+- HTTP `402 Payment Required`
+- `www-authenticate: L402 ...`
+- real BOLT11 invoice returned
+- real macaroon returned
+
+This means the provider is live enough to issue real payment challenges even though 402index health currently looks poor.
+
+### Sats4AI credibility summary
+Positive signals:
+
+- clear docs and product positioning
+- transparent per-service pricing
+- L402 + MCP + discovery docs
+- terms and contact pages exist
+- public GitHub repos exist and are recently updated
+- machine-readable catalog exists
+- valid live L402 payment challenges observed
+
+Caveats / red flags:
+
+- no clear team/about page found yet
+- weak public proof / social proof so far
+- GitHub repos are early / low-star
+- site is explicitly beta
+- 402index health appears inconsistent / weak
+
+Current recommendation:
+
+- **approved for trial**
+- promising but early
+- good enough to continue testing manually
+
+### Best first endpoint candidate
+Recommended first activation endpoint:
+
+- `translate-text`
+- `https://sats4ai.com/api/l402/translate-text`
+
+Why:
+
+- cheap
+- simple request body
+- easy synchronous response shape
+- clear landing-page value proposition
+- easier than audio / video / async workflows
+
+Fallback candidates:
+
+- `generate-text`
+- `convert-html-to-pdf`
+
+### Why `translate-text` is preferred over `generate-text`
+`generate-text` works, but translation is more differentiated and makes a better first landing-page story for a pay-per-use service.
+
+---
+
+## Wallet setup completed during this manual test
+We also set up wallet capability so the environment can complete real paid endpoint tests.
+
+### Skill installation
+The Alby payments skill content was saved locally as a custom skill at:
+
+- `/home/ubuntu/.hermes/skills/custom/alby-bitcoin-payments/SKILL.md`
+
+### Wallet auth flow
+Auth command run:
+
+```bash
+npx -y @getalby/cli@0.6.1 auth https://my.albyhub.com --app-name Hermes
+```
+
+Approval URL was generated and approved in Alby Hub.
+
+### Verification command
+Wallet access was verified with:
+
+```bash
+npx -y @getalby/cli@0.6.1 get-balance
+```
+
+Observed balance at setup time:
+
+- `10,000 sats`
+
+Conclusion:
+
+- the environment is now ready to perform real paid endpoint tests
+
+---
+
+## Recommended next implementation step
+The next repo work should be:
+
+1. add a provider registry + legacy backfill structure
+2. add Sats4AI as the first provider intake record
+3. record provider evaluation notes in git
+4. perform real end-to-end paid test for `translate-text`
+5. capture artifacts for future landing page generation
+
+---
+
+## Recommendation on documentation placement
+For now, a normal markdown file under `docs/` is better than introducing `AGENTS.md` immediately.
+
+Reason:
+
+- this repo currently has no `AGENTS.md`
+- we only need one durable planning / workflow document right now
+- `docs/provider-intake-and-activation.md` is easy to link from `README.md`
+- if the repo later accumulates multiple operational conventions, we can add a top-level `AGENTS.md` that points to the docs folder
+
+Current recommendation:
+
+- keep the detailed workflow in `docs/provider-intake-and-activation.md`
+- link it from `README.md`
+- add `AGENTS.md` later only if the repo grows enough to justify a dedicated operator guide

--- a/docs/provider-intake-and-activation.md
+++ b/docs/provider-intake-and-activation.md
@@ -69,7 +69,12 @@ We want two distinct workflows:
 
 ## Proposed future repository structure
 
-Not implemented yet, but this is the current direction.
+The first implementation step of this structure is now in place:
+
+- `src/registry/types.ts`
+- `src/registry/providers/*.ts`
+
+The registry is currently used as the durable provider decision layer and includes lightweight backfilled entries for legacy providers plus a new entry for Sats4AI.
 
 ```text
 registry/
@@ -280,6 +285,7 @@ Recommended first activation endpoint:
 Status:
 
 - **paid test completed successfully**
+- **landing page service added locally as `sats4ai-translate-text`**
 - detailed test record: `docs/provider-tests/sats4ai-translate-text-2026-04-19.md`
 
 Why:

--- a/docs/provider-tests/sats4ai-translate-text-2026-04-19.md
+++ b/docs/provider-tests/sats4ai-translate-text-2026-04-19.md
@@ -1,0 +1,117 @@
+# Sats4AI Translate Text — Paid Test Record
+
+**Timestamp:** 2026-04-19T08:20:38Z  
+**Provider:** Sats4AI  
+**Endpoint:** `https://sats4ai.com/api/l402/translate-text`  
+**Purpose:** First real paid provider-activation test for the 402 landing pages workflow.
+
+---
+
+## Request used
+
+```bash
+npx -y @getalby/cli@0.6.1 fetch https://sats4ai.com/api/l402/translate-text \
+  -X POST \
+  -H '{"Content-Type":"application/json"}' \
+  -b '{"text":"Hello world from Bitcoin. This is a manual provider activation test for the 402 landing pages project.","targetLanguage":"Spanish"}' \
+  --max-amount 100
+```
+
+### Request body
+
+```json
+{
+  "text": "Hello world from Bitcoin. This is a manual provider activation test for the 402 landing pages project.",
+  "targetLanguage": "Spanish"
+}
+```
+
+---
+
+## Result
+
+The Alby CLI completed the L402 payment flow successfully and returned:
+
+```json
+{
+  "content": "{\"translatedText\":\"Hola mundo desde Bitcoin. Este es un test de activación manual del proveedor para el proyecto de 402 páginas de aterrizaje.\",\"sourceLanguage\":\"auto-detected\",\"targetLanguage\":\"Spanish\"}"
+}
+```
+
+Parsed response:
+
+```json
+{
+  "translatedText": "Hola mundo desde Bitcoin. Este es un test de activación manual del proveedor para el proyecto de 402 páginas de aterrizaje.",
+  "sourceLanguage": "auto-detected",
+  "targetLanguage": "Spanish"
+}
+```
+
+---
+
+## Payment details
+
+Wallet balance before the test:
+
+```json
+{
+  "amount_in_sats": 10000
+}
+```
+
+Wallet balance after the test:
+
+```json
+{
+  "amount_in_sats": 9998
+}
+```
+
+Most recent outgoing transaction:
+
+```json
+{
+  "type": "outgoing",
+  "state": "settled",
+  "description": "Sats4AI - Translation - Standard - L402",
+  "amount_in_sats": 1,
+  "fees_paid_in_sats": 1,
+  "created_at": 1776586787,
+  "settled_at": 1776586800,
+  "payment_hash": "81a55015827d720d48aafb83459e3aac4b997abf43996487714455ca621318ee"
+}
+```
+
+### Cost summary
+
+- service cost: **1 sat**
+- routing / payment fees: **1 sat**
+- total wallet delta: **2 sats**
+- max spend guard used: **100 sats**
+
+---
+
+## Why this endpoint is a good first activation candidate
+
+- very cheap to test
+- synchronous request / response
+- easy to explain on a landing page
+- clear user value
+- response format is simple and easy to capture
+- easier than async audio / video / file workflows for v1
+
+---
+
+## Takeaways
+
+1. **Sats4AI passed the first real paid test.**
+2. **402index health alone is not enough to reject a provider.** The provider had poor health reporting there, but the real L402 payment flow worked.
+3. **`translate-text` is a strong first endpoint for provider activation.**
+4. We now have a concrete example of the minimal artifact set we should save for future provider activations:
+   - endpoint URL
+   - exact request
+   - exact response
+   - actual cost paid
+   - transaction evidence
+   - brief rationale for why the endpoint is landing-page-worthy

--- a/scripts/check-provider-registry.mjs
+++ b/scripts/check-provider-registry.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+
+const root = process.cwd();
+const registryDir = path.join(root, 'src/registry/providers');
+const registryIndexPath = path.join(root, 'src/registry/providers/index.ts');
+const registryTypesPath = path.join(root, 'src/registry/types.ts');
+
+assert.equal(fs.existsSync(registryDir), true, 'expected provider registry directory at src/registry/providers');
+assert.equal(fs.existsSync(registryIndexPath), true, 'expected provider registry index at src/registry/providers/index.ts');
+assert.equal(fs.existsSync(registryTypesPath), true, 'expected provider registry types at src/registry/types.ts');
+
+const providerFiles = fs.readdirSync(registryDir).filter((file) => file.endsWith('.ts') && file !== 'index.ts');
+for (const providerKey of ['payperq', 'cascade', 'l402-services', 'llm402', 'pull-that-up-jamie', 'sats4ai']) {
+  assert.ok(providerFiles.includes(`${providerKey}.ts`), `expected provider registry entry for ${providerKey}`);
+}
+
+const sats4aiSource = fs.readFileSync(path.join(registryDir, 'sats4ai.ts'), 'utf8');
+assert.ok(sats4aiSource.includes("reviewStatus: 'approved-for-trial'"), 'expected Sats4AI to be recorded as approved-for-trial');
+assert.ok(sats4aiSource.includes('translate-text'), 'expected Sats4AI registry entry to mention translate-text as an activation candidate');
+
+const payperqSource = fs.readFileSync(path.join(registryDir, 'payperq.ts'), 'utf8');
+assert.ok(payperqSource.includes('legacy-manual'), 'expected existing live providers to be backfilled as legacy-manual entries');
+
+console.log('provider registry looks good');

--- a/scripts/check-sats4ai-translation.mjs
+++ b/scripts/check-sats4ai-translation.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+
+const root = process.cwd();
+const serviceSource = fs.readFileSync(path.join(root, 'src/data/services/sats4ai-translate-text.ts'), 'utf8');
+const providerSource = fs.readFileSync(path.join(root, 'src/data/providers/sats4ai.ts'), 'utf8');
+const builtHomepage = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
+const builtLandingPage = fs.readFileSync(
+  path.join(root, 'dist/agents/hermes/sats4ai-translate-text/index.html'),
+  'utf8',
+);
+
+assert.ok(serviceSource.includes("key: 'sats4ai-translate-text'"), 'expected Sats4AI translation service definition to exist');
+assert.ok(serviceSource.includes('119 languages'), 'expected service copy to mention 119 languages');
+assert.ok(serviceSource.includes('1 sat per 1000 characters') || serviceSource.includes('1,000 characters per sat'), 'expected service copy to mention translation pricing');
+assert.ok(providerSource.includes("key: 'sats4ai'"), 'expected Sats4AI provider file to exist');
+assert.ok(providerSource.includes("supportStatus: 'supported'"), 'expected Sats4AI provider to be treated as supported after the successful paid test');
+assert.ok(builtHomepage.includes('Sats4AI'), 'expected homepage to include Sats4AI');
+assert.ok(builtLandingPage.includes('119 languages'), 'expected built Sats4AI landing page to mention 119 languages');
+assert.ok(builtLandingPage.includes('Hola mundo desde Bitcoin'), 'expected built Sats4AI landing page to include the captured translated output');
+assert.ok(builtLandingPage.includes('Install the Alby Payments Skill'), 'expected built Sats4AI landing page to keep the install CTA');
+
+console.log('sats4ai translation landing page looks good');

--- a/src/data/providers/sats4ai.ts
+++ b/src/data/providers/sats4ai.ts
@@ -1,0 +1,10 @@
+import type { Provider } from '../types';
+
+const provider = {
+  key: 'sats4ai',
+  name: 'Sats4AI',
+  websiteUrl: 'https://sats4ai.com',
+  supportStatus: 'supported',
+} satisfies Provider;
+
+export default provider;

--- a/src/data/services/sats4ai-translate-text.ts
+++ b/src/data/services/sats4ai-translate-text.ts
@@ -1,0 +1,64 @@
+import { createServiceDefinition } from '../service-factory';
+import type { ServiceDefinition } from '../types';
+
+const service = createServiceDefinition({
+  key: 'sats4ai-translate-text',
+  providerKey: 'sats4ai',
+  name: 'translate-text',
+  endpointUrl: 'https://sats4ai.com/api/l402/translate-text',
+  resultLabel: 'Translate text across 119 languages with a real paid API call',
+  category: 'Translation',
+  priceLabel: '1 sat per 1,000 characters (+ routing fees)',
+  exampleOutput: {
+    kind: 'table',
+    title: 'Example output',
+    caption:
+      'Real paid test result from the first Sats4AI provider activation run, showing the exact translated output returned by the API after a successful L402 payment.',
+    columns: ['Input', 'Target language', 'Output'],
+    rows: [
+      [
+        'Hello world from Bitcoin. This is a manual provider activation test for the 402 landing pages project.',
+        'Spanish',
+        'Hola mundo desde Bitcoin. Este es un test de activación manual del proveedor para el proyecto de 402 páginas de aterrizaje.',
+      ],
+    ],
+    details: [
+      'Provider: Sats4AI',
+      'Service: translate-text',
+      'Endpoint: /api/l402/translate-text',
+      'Observed cost: 1 sat translation + 1 sat routing fee',
+      'Coverage: 119 languages',
+    ],
+    briefingTitle: 'What the paid test showed',
+    briefingParagraphs: [
+      'The paid test completed successfully with a real L402 payment and returned a clean Spanish translation immediately.',
+      'This is a strong first activation endpoint because it is cheap, synchronous, and easy for a user to understand at a glance.',
+    ],
+  },
+  examplePromptHeading: 'Example request',
+  examplePrompt:
+    'Translate the following text to Spanish using Sats4AI: "Hello world from Bitcoin. This is a manual provider activation test for the 402 landing pages project."',
+  variantTitle: ({ agentName, providerName }) => `Translate text with ${agentName} using ${providerName}`,
+  variantDescription: ({ agentName, providerName }) =>
+    `Enable ${agentName} to translate text across 119 languages with ${providerName} for about 1 sat per 1,000 characters, with no account, no API key, and no human needed after setup.`,
+  heroSummary: ({ agentName, providerName, serviceName }) =>
+    `Give ${agentName} access to ${providerName} ${serviceName} so it can turn source text into translated output on demand without stopping for signup, billing setup, or manual copy-paste work.`,
+  heroBulletHighlights: () => [
+    'Supports 119 languages with auto-detected source language.',
+    'Pricing is about 1,000 characters per sat, which keeps routine translation cheap inside larger autonomous workflows.',
+  ],
+  whyItWorks: ({ agentName, providerName }) => [
+    `${agentName} can translate short text immediately instead of stalling on account creation or switching to a separate SaaS dashboard.`,
+    `${providerName} keeps the request shape simple enough that a low-cost paid translation can fit naturally inside research, support, and publishing workflows.`,
+    'The successful paid test shows that one real L402 request can produce useful multilingual output with minimal operational overhead.',
+  ],
+  useCases: () => [
+    'Translate support replies or product copy into another language',
+    'Localize research notes or summaries before sharing them with a global audience',
+    'Add multilingual translation as a cheap helper step inside a broader agent workflow',
+  ],
+  faqResultDescription: () =>
+    'Sats4AI translate-text returns structured translation results with the translated text, detected source language, and requested target language, making it easy to slot into multilingual agent workflows.',
+}) satisfies ServiceDefinition;
+
+export default service;

--- a/src/registry/providers/cascade.ts
+++ b/src/registry/providers/cascade.ts
@@ -1,0 +1,17 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'cascade',
+  name: 'Cascade',
+  websiteUrl: 'https://cascade.fyi',
+  protocols: ['L402'],
+  discoverySources: ['legacy-manual'],
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  backfilled: true,
+  summary: 'Legacy provider already represented in landing pages and backfilled into the provider registry.',
+  notes: ['Backfilled as an existing coming-soon provider.'],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/index.ts
+++ b/src/registry/providers/index.ts
@@ -1,0 +1,13 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const providerModules = import.meta.glob('./*.ts', { eager: true }) as Record<string, { default?: ProviderRegistryEntry }>;
+
+export const providerRegistryEntries: ProviderRegistryEntry[] = Object.entries(providerModules)
+  .filter(([path]) => path !== './index.ts')
+  .map(([, module]) => module.default)
+  .filter((provider): provider is ProviderRegistryEntry => Boolean(provider))
+  .sort((a, b) => a.key.localeCompare(b.key));
+
+export const providerRegistryByKey = Object.fromEntries(
+  providerRegistryEntries.map((provider) => [provider.key, provider]),
+) as Record<string, ProviderRegistryEntry>;

--- a/src/registry/providers/l402-services.ts
+++ b/src/registry/providers/l402-services.ts
@@ -1,0 +1,17 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'l402-services',
+  name: 'L402 Services',
+  websiteUrl: 'https://l402.services',
+  protocols: ['L402'],
+  discoverySources: ['legacy-manual'],
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  backfilled: true,
+  summary: 'Legacy provider already live in landing pages before the registry was introduced.',
+  notes: ['Backfilled as an existing supported provider.'],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/llm402.ts
+++ b/src/registry/providers/llm402.ts
@@ -1,0 +1,17 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'llm402',
+  name: 'llm402.ai',
+  websiteUrl: 'https://llm402.ai',
+  protocols: ['L402'],
+  discoverySources: ['legacy-manual'],
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  backfilled: true,
+  summary: 'Legacy provider already live in landing pages before the registry was introduced.',
+  notes: ['Backfilled as an existing supported provider.'],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/payperq.ts
+++ b/src/registry/providers/payperq.ts
@@ -1,0 +1,17 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'payperq',
+  name: 'PayPerQ',
+  websiteUrl: 'https://ppq.ai',
+  protocols: ['L402'],
+  discoverySources: ['legacy-manual'],
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  backfilled: true,
+  summary: 'Legacy provider already live in landing pages before the provider registry existed.',
+  notes: ['Backfilled as an existing supported provider.'],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/pull-that-up-jamie.ts
+++ b/src/registry/providers/pull-that-up-jamie.ts
@@ -1,0 +1,17 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'pull-that-up-jamie',
+  name: 'Pull That Up Jamie',
+  websiteUrl: 'https://www.pullthatupjamie.ai',
+  protocols: ['L402'],
+  discoverySources: ['legacy-manual'],
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  backfilled: true,
+  summary: 'Legacy provider already live in landing pages before the registry was introduced.',
+  notes: ['Backfilled as an existing supported provider.'],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/sats4ai.ts
+++ b/src/registry/providers/sats4ai.ts
@@ -1,0 +1,22 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'sats4ai',
+  name: 'Sats4AI',
+  websiteUrl: 'https://sats4ai.com',
+  protocols: ['L402', 'MPP'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'live',
+  summary:
+    'Promising but early provider discovered on 402index and validated manually with a real paid translation test despite poor 402index health signals.',
+  endpointCandidates: ['translate-text', 'generate-text', 'convert-html-to-pdf'],
+  notes: [
+    'translate-text completed a successful paid activation test on 2026-04-19.',
+    '402index currently reports weak health, but direct L402 challenge + paid retry succeeded.',
+    'Public docs, MCP docs, llms.txt, and /.well-known/l402-services are available.',
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,0 +1,21 @@
+export type ProviderReviewStatus = 'approved' | 'approved-for-trial' | 'rejected' | 'deferred' | 'duplicate';
+
+export type ProviderActivationStatus = 'not-started' | 'tested' | 'live';
+
+export type ProviderReviewSource = 'legacy-manual' | 'manual-intake';
+
+export type ProviderRegistryEntry = {
+  key: string;
+  name: string;
+  websiteUrl: string;
+  protocols: string[];
+  discoverySources: string[];
+  reviewStatus: ProviderReviewStatus;
+  reviewSource: ProviderReviewSource;
+  activationStatus: ProviderActivationStatus;
+  backfilled?: boolean;
+  summary: string;
+  notes?: string[];
+  endpointCandidates?: string[];
+  duplicateOf?: string;
+};


### PR DESCRIPTION
## Summary
- add a first `src/registry/` provider registry layer and backfill the currently live providers as lightweight legacy-approved entries
- record `Sats4AI` as the first newly evaluated provider and add landing-page data for the already paid-tested `translate-text` endpoint
- document the provider intake/activation workflow and add verification scripts for the registry and Sats4AI translation landing pages

## Test Plan
- [x] node scripts/check-provider-registry.mjs
- [x] npm run build
- [x] node scripts/check-sats4ai-translation.mjs
- [x] node scripts/check-homepage.mjs
- [x] node scripts/check-route-structure.mjs
- [x] node scripts/check-install-commands.mjs