### PR TITLE
feat: add service registry and more sats4ai pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Expected production URL:
 
 ## Workflow notes and planning
 
-- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, registry direction, Sats4AI evaluation notes, wallet setup notes, live paid-test summary, and registry implementation notes
+- `docs/provider-intake-and-activation.md` — manual provider-intake workflow, provider and service registry direction, Sats4AI evaluation notes, wallet setup notes, live paid-test summary, and registry implementation notes
 - `docs/provider-tests/sats4ai-translate-text-2026-04-19.md` — first successful end-to-end paid endpoint test record for Sats4AI translation
 
 ## What still needs to be done
@@ -103,8 +103,9 @@ In my opinion, the next useful steps are:
 1. replace the mock output image and mock payment amount with real captured example outputs once the payment flow is tested
 2. decide the final CTA destination and install UX for Bitcoin-compatible 402 services
 3. improve SEO metadata per variant, including canonical strategy, Open Graph images, and structured data
-4. add automation that can generate N agent-specific pages from one approved provider/service record
-5. add checks for thin or duplicate copy as the number of agents, providers, and services grows
+4. keep provider and service registry entries fresh with real last-checked dates as more endpoints are reviewed
+5. add automation that can generate N agent-specific pages from one approved provider/service record
+6. add checks for thin or duplicate copy as the number of agents, providers, and services grows
 
 ## Why Astro here
 

--- a/docs/provider-intake-and-activation.md
+++ b/docs/provider-intake-and-activation.md
@@ -286,6 +286,8 @@ Status:
 
 - **paid test completed successfully**
 - **landing page service added locally as `sats4ai-translate-text`**
+- **service registry now records endpoint-level status separately from provider status, so additional Sats4AI pages can stay coming-soon until each endpoint is paid-tested**
+- **provider and service registry entries now include `lastCheckedAt` so review freshness is visible in git**
 - detailed test record: `docs/provider-tests/sats4ai-translate-text-2026-04-19.md`
 
 Why:

--- a/scripts/check-provider-registry.mjs
+++ b/scripts/check-provider-registry.mjs
@@ -11,6 +11,9 @@ assert.equal(fs.existsSync(registryDir), true, 'expected provider registry direc
 assert.equal(fs.existsSync(registryIndexPath), true, 'expected provider registry index at src/registry/providers/index.ts');
 assert.equal(fs.existsSync(registryTypesPath), true, 'expected provider registry types at src/registry/types.ts');
 
+const typesSource = fs.readFileSync(registryTypesPath, 'utf8');
+assert.ok(typesSource.includes('lastCheckedAt: string;'), 'expected provider registry types to include lastCheckedAt');
+
 const providerFiles = fs.readdirSync(registryDir).filter((file) => file.endsWith('.ts') && file !== 'index.ts');
 for (const providerKey of ['payperq', 'cascade', 'l402-services', 'llm402', 'pull-that-up-jamie', 'sats4ai']) {
   assert.ok(providerFiles.includes(`${providerKey}.ts`), `expected provider registry entry for ${providerKey}`);
@@ -18,9 +21,12 @@ for (const providerKey of ['payperq', 'cascade', 'l402-services', 'llm402', 'pul
 
 const sats4aiSource = fs.readFileSync(path.join(registryDir, 'sats4ai.ts'), 'utf8');
 assert.ok(sats4aiSource.includes("reviewStatus: 'approved-for-trial'"), 'expected Sats4AI to be recorded as approved-for-trial');
-assert.ok(sats4aiSource.includes('translate-text'), 'expected Sats4AI registry entry to mention translate-text as an activation candidate');
+assert.ok(sats4aiSource.includes("lastCheckedAt: '2026-04-19'"), 'expected Sats4AI provider registry entry to record the last-checked date');
+assert.ok(sats4aiSource.includes('generate-text'), 'expected Sats4AI registry entry to mention generate-text as an activation candidate');
+assert.ok(sats4aiSource.includes('convert-html-to-pdf'), 'expected Sats4AI registry entry to mention convert-html-to-pdf as an activation candidate');
 
 const payperqSource = fs.readFileSync(path.join(registryDir, 'payperq.ts'), 'utf8');
 assert.ok(payperqSource.includes('legacy-manual'), 'expected existing live providers to be backfilled as legacy-manual entries');
+assert.ok(payperqSource.includes("lastCheckedAt: '2026-04-19'"), 'expected backfilled providers to record a last-checked date');
 
 console.log('provider registry looks good');

--- a/scripts/check-sats4ai-service-statuses.mjs
+++ b/scripts/check-sats4ai-service-statuses.mjs
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+
+const root = process.cwd();
+
+const supportedPage = fs.readFileSync(path.join(root, 'dist/agents/hermes/sats4ai-translate-text/index.html'), 'utf8');
+const generateTextPage = fs.readFileSync(path.join(root, 'dist/agents/hermes/sats4ai-generate-text/index.html'), 'utf8');
+const pdfPage = fs.readFileSync(path.join(root, 'dist/agents/hermes/sats4ai-convert-html-to-pdf/index.html'), 'utf8');
+const imagePage = fs.readFileSync(path.join(root, 'dist/agents/hermes/sats4ai-analyze-image/index.html'), 'utf8');
+const buildVariantsSource = fs.readFileSync(path.join(root, 'src/data/build-variants.ts'), 'utf8');
+
+assert.ok(buildVariantsSource.includes('const supportStatus = service.supportStatus;'), 'expected landing-page build variants to use service-level support status');
+assert.ok(supportedPage.includes('/install/hermes/'), 'expected paid-tested Sats4AI translation to point at install');
+assert.ok(generateTextPage.includes('/coming-soon/hermes/'), 'expected untested Sats4AI generate-text to point at coming-soon');
+assert.ok(pdfPage.includes('/coming-soon/hermes/'), 'expected untested Sats4AI convert-html-to-pdf to point at coming-soon');
+assert.ok(imagePage.includes('/coming-soon/hermes/'), 'expected untested Sats4AI analyze-image to point at coming-soon');
+
+console.log('sats4ai service support statuses look good');

--- a/scripts/check-sats4ai-translation.mjs
+++ b/scripts/check-sats4ai-translation.mjs
@@ -12,10 +12,12 @@ const builtLandingPage = fs.readFileSync(
 );
 
 assert.ok(serviceSource.includes("key: 'sats4ai-translate-text'"), 'expected Sats4AI translation service definition to exist');
+assert.ok(serviceSource.includes("supportStatus: 'supported'"), 'expected Sats4AI translation to stay supported after the paid test');
+assert.ok(serviceSource.includes("lastCheckedAt: '2026-04-19'"), 'expected Sats4AI translation service to record a last-checked date');
 assert.ok(serviceSource.includes('119 languages'), 'expected service copy to mention 119 languages');
 assert.ok(serviceSource.includes('1 sat per 1000 characters') || serviceSource.includes('1,000 characters per sat'), 'expected service copy to mention translation pricing');
 assert.ok(providerSource.includes("key: 'sats4ai'"), 'expected Sats4AI provider file to exist');
-assert.ok(providerSource.includes("supportStatus: 'supported'"), 'expected Sats4AI provider to be treated as supported after the successful paid test');
+assert.ok(providerSource.includes("lastCheckedAt: '2026-04-19'"), 'expected Sats4AI provider to record a last-checked date');
 assert.ok(builtHomepage.includes('Sats4AI'), 'expected homepage to include Sats4AI');
 assert.ok(builtLandingPage.includes('119 languages'), 'expected built Sats4AI landing page to mention 119 languages');
 assert.ok(builtLandingPage.includes('Hola mundo desde Bitcoin'), 'expected built Sats4AI landing page to include the captured translated output');

--- a/scripts/check-service-registry.mjs
+++ b/scripts/check-service-registry.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import assert from 'node:assert/strict';
+
+const root = process.cwd();
+const registryDir = path.join(root, 'src/registry/services');
+const registryIndexPath = path.join(root, 'src/registry/services/index.ts');
+const registryTypesPath = path.join(root, 'src/registry/types.ts');
+const dataTypesPath = path.join(root, 'src/data/types.ts');
+
+assert.equal(fs.existsSync(registryDir), true, 'expected service registry directory at src/registry/services');
+assert.equal(fs.existsSync(registryIndexPath), true, 'expected service registry index at src/registry/services/index.ts');
+
+const registryTypes = fs.readFileSync(registryTypesPath, 'utf8');
+const dataTypes = fs.readFileSync(dataTypesPath, 'utf8');
+assert.ok(registryTypes.includes('export type ServiceRegistryEntry = {'), 'expected service registry type to exist');
+assert.ok(registryTypes.includes('landingPageStatus: RegistrySupportStatus;'), 'expected service registry entries to track landing-page support status');
+assert.ok(dataTypes.includes('lastCheckedAt: string;'), 'expected data types to track last-checked dates');
+assert.ok(dataTypes.includes('supportStatus: SupportStatus;'), 'expected service data to track support status');
+
+const serviceFiles = fs.readdirSync(registryDir).filter((file) => file.endsWith('.ts') && file !== 'index.ts');
+for (const serviceKey of [
+  'payperq-gpt-image-1-5',
+  'cascade-tweet-search',
+  'l402-services-predictions-oracle',
+  'llm402-flux-1-schnell-image-generation',
+  'llm402-gpt-5-image-generation',
+  'pull-that-up-jamie-search-quotes',
+  'sats4ai-translate-text',
+  'sats4ai-generate-text',
+  'sats4ai-convert-html-to-pdf',
+  'sats4ai-analyze-image',
+]) {
+  assert.ok(serviceFiles.includes(`${serviceKey}.ts`), `expected service registry entry for ${serviceKey}`);
+}
+
+const translateRegistry = fs.readFileSync(path.join(registryDir, 'sats4ai-translate-text.ts'), 'utf8');
+assert.ok(translateRegistry.includes("activationStatus: 'live'"), 'expected sats4ai translate-text to be marked live in the service registry');
+assert.ok(translateRegistry.includes("landingPageStatus: 'supported'"), 'expected sats4ai translate-text to be marked supported in the service registry');
+
+const generateRegistry = fs.readFileSync(path.join(registryDir, 'sats4ai-generate-text.ts'), 'utf8');
+assert.ok(generateRegistry.includes("activationStatus: 'schema-checked'"), 'expected sats4ai generate-text to be marked schema-checked');
+assert.ok(generateRegistry.includes("landingPageStatus: 'coming-soon'"), 'expected sats4ai generate-text to stay coming-soon');
+
+console.log('service registry looks good');

--- a/src/data/build-variants.ts
+++ b/src/data/build-variants.ts
@@ -27,6 +27,7 @@ const buildCta = (agentKey: string, supportStatus: 'supported' | 'coming-soon'):
 export const variants: LandingVariant[] = agents.flatMap((agent) =>
   serviceDefinitions.map((service) => {
     const provider = providersByKey[service.providerKey];
+    const supportStatus = service.supportStatus;
     const context = {
       agentName: agent.name,
       providerName: provider.name,
@@ -40,8 +41,10 @@ export const variants: LandingVariant[] = agents.flatMap((agent) =>
       agentLogoSrc: agent.logoSrc,
       providerKey: provider.key,
       providerName: provider.name,
+      providerLastCheckedAt: provider.lastCheckedAt,
       serviceKey: service.key,
       serviceName: service.name,
+      serviceLastCheckedAt: service.lastCheckedAt,
       slug: service.key,
       endpointUrl: service.endpointUrl,
       resultLabel: service.resultLabel,
@@ -62,8 +65,8 @@ export const variants: LandingVariant[] = agents.flatMap((agent) =>
         providerName: provider.name,
         serviceName: service.name,
       }),
-      cta: buildCta(agent.key, provider.supportStatus),
-      supportStatus: provider.supportStatus,
+      cta: buildCta(agent.key, supportStatus),
+      supportStatus,
     };
   }),
 );

--- a/src/data/providers/cascade.ts
+++ b/src/data/providers/cascade.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'cascade',
   name: 'Cascade',
   websiteUrl: 'https://cascade.fyi',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'coming-soon',
 } satisfies Provider;
 

--- a/src/data/providers/l402-services.ts
+++ b/src/data/providers/l402-services.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'l402-services',
   name: 'L402 Services',
   websiteUrl: 'https://l402.services',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'supported',
 } satisfies Provider;
 

--- a/src/data/providers/llm402.ts
+++ b/src/data/providers/llm402.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'llm402',
   name: 'llm402.ai',
   websiteUrl: 'https://llm402.ai',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'supported',
 } satisfies Provider;
 

--- a/src/data/providers/payperq.ts
+++ b/src/data/providers/payperq.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'payperq',
   name: 'PayPerQ',
   websiteUrl: 'https://ppq.ai',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'supported',
 } satisfies Provider;
 

--- a/src/data/providers/pull-that-up-jamie.ts
+++ b/src/data/providers/pull-that-up-jamie.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'pull-that-up-jamie',
   name: 'Pull That Up Jamie',
   websiteUrl: 'https://www.pullthatupjamie.ai',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'supported',
 } satisfies Provider;
 

--- a/src/data/providers/sats4ai.ts
+++ b/src/data/providers/sats4ai.ts
@@ -4,6 +4,7 @@ const provider = {
   key: 'sats4ai',
   name: 'Sats4AI',
   websiteUrl: 'https://sats4ai.com',
+  lastCheckedAt: '2026-04-19',
   supportStatus: 'supported',
 } satisfies Provider;
 

--- a/src/data/services/cascade-tweet-search.ts
+++ b/src/data/services/cascade-tweet-search.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://twitter.surf.cascade.fyi/tweets/search',
   resultLabel: 'Search and summarize live Twitter results on demand',
   category: 'Social search',
+  supportStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '$0.04',
   exampleOutput: {
     kind: 'table',

--- a/src/data/services/l402-services-predictions-oracle.ts
+++ b/src/data/services/l402-services-predictions-oracle.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://l402.services/predictions/oracle',
   resultLabel: 'Turn live prediction-market data into a written intelligence briefing',
   category: 'Research intelligence',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '250 sats (~$0.07)',
   exampleOutput: {
     kind: 'table',

--- a/src/data/services/llm402-flux-1-schnell-image-generation.ts
+++ b/src/data/services/llm402-flux-1-schnell-image-generation.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://llm402.ai/v1/images/generations',
   resultLabel: 'Generate images on demand for real-time agent workflows',
   category: 'Image generation',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '21 sats (~$0.01)',
   exampleOutput: {
     kind: 'image',

--- a/src/data/services/llm402-gpt-5-image-generation.ts
+++ b/src/data/services/llm402-gpt-5-image-generation.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://llm402.ai/v1/images/generations',
   resultLabel: 'Generate detailed, user-facing images on demand',
   category: 'Image generation',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '105 sats (~$0.03)',
   exampleOutput: {
     kind: 'image',

--- a/src/data/services/payperq-gpt-image-1-5.ts
+++ b/src/data/services/payperq-gpt-image-1-5.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://api.ppq.ai/v1/images/generations/gpt-image-1.5',
   resultLabel: 'Generate polished images on demand',
   category: 'Image generation',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '$0.08',
   exampleOutput: {
     kind: 'image',

--- a/src/data/services/pull-that-up-jamie-search-quotes.ts
+++ b/src/data/services/pull-that-up-jamie-search-quotes.ts
@@ -9,6 +9,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://www.pullthatupjamie.ai/api/search-quotes',
   resultLabel: 'Find exact spoken podcast moments with timestamps and clip links',
   category: 'Podcast search',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '6 sats',
   exampleOutput: {
     kind: 'table',

--- a/src/data/services/sats4ai-analyze-image.ts
+++ b/src/data/services/sats4ai-analyze-image.ts
@@ -1,0 +1,63 @@
+import { createServiceDefinition } from '../service-factory';
+import type { ServiceDefinition } from '../types';
+
+const service = createServiceDefinition({
+  key: 'sats4ai-analyze-image',
+  providerKey: 'sats4ai',
+  name: 'analyze-image',
+  endpointUrl: 'https://sats4ai.com/api/l402/analyze-image',
+  resultLabel: 'Analyze images with a paid vision endpoint instead of waiting for a human pass',
+  category: 'Vision analysis',
+  supportStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  priceLabel: '21 sats per image analysis',
+  exampleOutput: {
+    kind: 'table',
+    title: 'What this endpoint is built for',
+    caption:
+      'Sats4AI exposes analyze-image as a vision endpoint that takes image data plus a question or instruction and returns a paid analysis result.',
+    columns: ['Capability', 'Details'],
+    rows: [
+      ['Input shape', 'Base64 image data URI plus a natural-language prompt'],
+      ['Model path', 'Vision model route optimized for analysis tasks'],
+      ['Typical result', 'Structured image understanding or direct visual Q&A output'],
+    ],
+    details: [
+      'Provider: Sats4AI',
+      'Service: analyze-image',
+      'Endpoint: /api/l402/analyze-image',
+      'Checked: live schema confirmed on 2026-04-19',
+    ],
+    briefingTitle: 'Why this is useful',
+    briefingParagraphs: [
+      'A lot of agent work still gets blocked by screenshots, product images, receipts, and diagrams that need visual interpretation before the workflow can continue.',
+      'This landing page stays on the coming-soon path until we run a real paid image-analysis request and capture the result.',
+    ],
+  },
+  examplePromptHeading: 'Example request',
+  examplePrompt:
+    'Analyze this screenshot and tell me what the page is for, what the main CTA is, and whether any error state is visible.',
+  variantTitle: ({ agentName, providerName }) => `Analyze images with ${agentName} using ${providerName}`,
+  variantDescription: ({ agentName, providerName }) =>
+    `Enable ${agentName} to inspect screenshots, diagrams, and photos with ${providerName} instead of waiting for manual visual review each time.`,
+  heroSummary: ({ agentName, providerName, serviceName }) =>
+    `Give ${agentName} access to ${providerName} ${serviceName} so it can answer visual questions from screenshots and uploaded images without switching into a separate hosted workspace.`,
+  heroBulletHighlights: () => [
+    'Takes image data plus a natural-language question or instruction.',
+    'Useful for screenshots, diagrams, product images, and visual QA tasks.',
+  ],
+  whyItWorks: ({ agentName, providerName }) => [
+    `${agentName} can keep a workflow moving when the missing context is inside an image rather than plain text.`,
+    `${providerName} packages vision analysis as a direct paid endpoint, which is a cleaner fit than provisioning another dashboard or seat-based vision tool.`,
+    'That can make debugging, research, support, and content-review loops faster when screenshots are part of the job.',
+  ],
+  useCases: () => [
+    'Inspect screenshots during debugging or QA',
+    'Answer questions about product images or diagrams',
+    'Summarize visual context before handing work to a human reviewer',
+  ],
+  faqResultDescription: () =>
+    'Sats4AI analyze-image is designed to return vision analysis from an image plus prompt, so agents can answer visual questions with a direct paid API call.',
+}) satisfies ServiceDefinition;
+
+export default service;

--- a/src/data/services/sats4ai-convert-html-to-pdf.ts
+++ b/src/data/services/sats4ai-convert-html-to-pdf.ts
@@ -1,0 +1,69 @@
+import { createServiceDefinition } from '../service-factory';
+import type { ServiceDefinition } from '../types';
+
+const service = createServiceDefinition({
+  key: 'sats4ai-convert-html-to-pdf',
+  providerKey: 'sats4ai',
+  name: 'convert-html-to-pdf',
+  endpointUrl: 'https://sats4ai.com/api/l402/convert-html-to-pdf',
+  resultLabel: 'Turn HTML or Markdown into PDFs with a paid endpoint instead of a separate export toolchain',
+  category: 'Document conversion',
+  supportStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  priceLabel: '50 sats per PDF conversion',
+  exampleOutput: {
+    kind: 'table',
+    title: 'What this endpoint is built for',
+    caption:
+      'Sats4AI exposes convert-html-to-pdf as a paid utility endpoint for agents that need clean PDF export from HTML or Markdown content.',
+    columns: ['Capability', 'Details'],
+    rows: [
+      ['Accepted input', 'HTML content or Markdown content in a single JSON field'],
+      ['Format selector', 'Choose html or markdown explicitly'],
+      ['Typical result', 'A generated PDF suitable for delivery or archiving'],
+    ],
+    details: [
+      'Provider: Sats4AI',
+      'Service: convert-html-to-pdf',
+      'Endpoint: /api/l402/convert-html-to-pdf',
+      'Checked: live schema confirmed on 2026-04-19',
+    ],
+    briefingTitle: 'Why this matters for agents',
+    briefingParagraphs: [
+      'An agent often already has structured HTML or Markdown ready to go, but still needs a PDF export step before handing work off to people or other systems.',
+      'This landing page stays on the coming-soon path until we capture one real paid conversion run.',
+    ],
+  },
+  examplePromptHeading: 'Example request',
+  examplePrompt: `Convert this Markdown meeting brief into a shareable PDF: "# Sprint update
+
+## Shipped
+- Added NWC support
+- Fixed webhook retries
+
+## Next
+- Ship provider registry"`,
+  variantTitle: ({ agentName, providerName }) => `Convert HTML or Markdown to PDF with ${agentName} using ${providerName}`,
+  variantDescription: ({ agentName, providerName }) =>
+    `Enable ${agentName} to turn HTML or Markdown into shareable PDFs with ${providerName} instead of hand-building export workflows or paid SaaS seats.`,
+  heroSummary: ({ agentName, providerName, serviceName }) =>
+    `Give ${agentName} access to ${providerName} ${serviceName} so it can produce PDFs directly from structured content without bouncing through a browser export flow.`,
+  heroBulletHighlights: () => [
+    'Works for both HTML and Markdown source content.',
+    'Useful when an agent needs a final deliverable, not just raw text.',
+  ],
+  whyItWorks: ({ agentName, providerName }) => [
+    `${agentName} can generate reports or briefs in text first, then turn them into PDFs in the same flow instead of stopping for a manual export step.`,
+    `${providerName} keeps the request shape simple enough that PDF generation can become a cheap utility action inside broader automations.`,
+    'That makes handoff to email, archives, and human review much easier than shipping only raw Markdown or HTML.',
+  ],
+  useCases: () => [
+    'Export generated reports or meeting briefs as PDFs',
+    'Create shareable customer-facing summaries from Markdown output',
+    'Archive agent-generated content in a PDF-friendly format',
+  ],
+  faqResultDescription: () =>
+    'Sats4AI convert-html-to-pdf is designed to return a generated PDF from HTML or Markdown input so agent workflows can end with a document, not just source markup.',
+}) satisfies ServiceDefinition;
+
+export default service;

--- a/src/data/services/sats4ai-generate-text.ts
+++ b/src/data/services/sats4ai-generate-text.ts
@@ -1,0 +1,63 @@
+import { createServiceDefinition } from '../service-factory';
+import type { ServiceDefinition } from '../types';
+
+const service = createServiceDefinition({
+  key: 'sats4ai-generate-text',
+  providerKey: 'sats4ai',
+  name: 'generate-text',
+  endpointUrl: 'https://sats4ai.com/api/l402/generate-text',
+  resultLabel: 'Generate text with per-character Lightning pricing and no API key',
+  category: 'Text generation',
+  supportStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  priceLabel: 'About 100 to 1,000 characters per sat depending on model and route',
+  exampleOutput: {
+    kind: 'table',
+    title: 'What this endpoint is built for',
+    caption:
+      'Sats4AI exposes generate-text as a chat-style paid endpoint for agents that need text generation without account setup or subscription management.',
+    columns: ['Capability', 'Details'],
+    rows: [
+      ['Input shape', 'Chat-style JSON with role/content messages'],
+      ['Optional context', 'fileContext text and imageData for richer prompts'],
+      ['Payment model', 'Per-character pricing after a Lightning invoice challenge'],
+    ],
+    details: [
+      'Provider: Sats4AI',
+      'Service: generate-text',
+      'Endpoint: /api/l402/generate-text',
+      'Checked: live schema confirmed on 2026-04-19',
+    ],
+    briefingTitle: 'Why this page is live before paid activation',
+    briefingParagraphs: [
+      'The endpoint is publicly documented and reachable today, so it is a good candidate to explain the user value before we run a paid activation test.',
+      'Until a real paid run is captured, this service stays on the coming-soon path instead of the install path.',
+    ],
+  },
+  examplePromptHeading: 'Example request',
+  examplePrompt:
+    'Generate a concise release note summary for a Bitcoin wallet update using a friendly, technical tone and include 3 bullet points.',
+  variantTitle: ({ agentName, providerName }) => `Generate text with ${agentName} using ${providerName}`,
+  variantDescription: ({ agentName, providerName }) =>
+    `Enable ${agentName} to generate drafts, summaries, and chat-style text with ${providerName} using Lightning-priced requests instead of prepaid API plans.`,
+  heroSummary: ({ agentName, providerName, serviceName }) =>
+    `Give ${agentName} access to ${providerName} ${serviceName} so it can produce paid text output on demand without waiting for account creation, seat management, or monthly billing setup.`,
+  heroBulletHighlights: () => [
+    'Works with chat-style JSON input that fits naturally into agent workflows.',
+    'Per-character pricing can make short drafting and summarization tasks cheap to run.',
+  ],
+  whyItWorks: ({ agentName, providerName }) => [
+    `${agentName} can ask for text output exactly when it needs it instead of forcing a human to switch tools or copy prompts into a separate UI.`,
+    `${providerName} exposes a direct paid endpoint that keeps access lightweight for one-off drafts, summaries, and rewrite steps.`,
+    'This can slot into research, support, documentation, and publishing flows where short-form text generation is a helper rather than the whole product.',
+  ],
+  useCases: () => [
+    'Draft summaries from internal notes or changelogs',
+    'Rewrite rough text into cleaner customer-facing copy',
+    'Generate first-pass research takeaways before a human review',
+  ],
+  faqResultDescription: () =>
+    'Sats4AI generate-text is designed to return generated text from chat-style requests, with pricing that scales to the amount of text and model path used.',
+}) satisfies ServiceDefinition;
+
+export default service;

--- a/src/data/services/sats4ai-translate-text.ts
+++ b/src/data/services/sats4ai-translate-text.ts
@@ -8,6 +8,8 @@ const service = createServiceDefinition({
   endpointUrl: 'https://sats4ai.com/api/l402/translate-text',
   resultLabel: 'Translate text across 119 languages with a real paid API call',
   category: 'Translation',
+  supportStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
   priceLabel: '1 sat per 1,000 characters (+ routing fees)',
   exampleOutput: {
     kind: 'table',

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -57,6 +57,7 @@ export type Provider = {
   name: string;
   websiteUrl: string;
   supportStatus: SupportStatus;
+  lastCheckedAt: string;
 };
 
 export type ServiceDefinition = {
@@ -66,6 +67,8 @@ export type ServiceDefinition = {
   endpointUrl: string;
   resultLabel: string;
   category: string;
+  supportStatus: SupportStatus;
+  lastCheckedAt: string;
   priceLabel: string;
   paymentLabel: string;
   exampleOutput: ExampleOutput;
@@ -87,8 +90,10 @@ export type LandingVariant = {
   agentLogoSrc: string;
   providerKey: string;
   providerName: string;
+  providerLastCheckedAt: string;
   serviceKey: string;
   serviceName: string;
+  serviceLastCheckedAt: string;
   slug: string;
   endpointUrl: string;
   resultLabel: string;

--- a/src/registry/providers/cascade.ts
+++ b/src/registry/providers/cascade.ts
@@ -9,6 +9,7 @@ const provider = {
   reviewStatus: 'approved',
   reviewSource: 'legacy-manual',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   backfilled: true,
   summary: 'Legacy provider already represented in landing pages and backfilled into the provider registry.',
   notes: ['Backfilled as an existing coming-soon provider.'],

--- a/src/registry/providers/l402-services.ts
+++ b/src/registry/providers/l402-services.ts
@@ -9,6 +9,7 @@ const provider = {
   reviewStatus: 'approved',
   reviewSource: 'legacy-manual',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   backfilled: true,
   summary: 'Legacy provider already live in landing pages before the registry was introduced.',
   notes: ['Backfilled as an existing supported provider.'],

--- a/src/registry/providers/llm402.ts
+++ b/src/registry/providers/llm402.ts
@@ -9,6 +9,7 @@ const provider = {
   reviewStatus: 'approved',
   reviewSource: 'legacy-manual',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   backfilled: true,
   summary: 'Legacy provider already live in landing pages before the registry was introduced.',
   notes: ['Backfilled as an existing supported provider.'],

--- a/src/registry/providers/payperq.ts
+++ b/src/registry/providers/payperq.ts
@@ -9,6 +9,7 @@ const provider = {
   reviewStatus: 'approved',
   reviewSource: 'legacy-manual',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   backfilled: true,
   summary: 'Legacy provider already live in landing pages before the provider registry existed.',
   notes: ['Backfilled as an existing supported provider.'],

--- a/src/registry/providers/pull-that-up-jamie.ts
+++ b/src/registry/providers/pull-that-up-jamie.ts
@@ -9,6 +9,7 @@ const provider = {
   reviewStatus: 'approved',
   reviewSource: 'legacy-manual',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   backfilled: true,
   summary: 'Legacy provider already live in landing pages before the registry was introduced.',
   notes: ['Backfilled as an existing supported provider.'],

--- a/src/registry/providers/sats4ai.ts
+++ b/src/registry/providers/sats4ai.ts
@@ -9,11 +9,13 @@ const provider = {
   reviewStatus: 'approved-for-trial',
   reviewSource: 'manual-intake',
   activationStatus: 'live',
+  lastCheckedAt: '2026-04-19',
   summary:
     'Promising but early provider discovered on 402index and validated manually with a real paid translation test despite poor 402index health signals.',
-  endpointCandidates: ['translate-text', 'generate-text', 'convert-html-to-pdf'],
+  endpointCandidates: ['translate-text', 'generate-text', 'convert-html-to-pdf', 'analyze-image'],
   notes: [
     'translate-text completed a successful paid activation test on 2026-04-19.',
+    'generate-text, convert-html-to-pdf, and analyze-image were schema-checked on 2026-04-19 but are still untested for paid activation.',
     '402index currently reports weak health, but direct L402 challenge + paid retry succeeded.',
     'Public docs, MCP docs, llms.txt, and /.well-known/l402-services are available.',
   ],

--- a/src/registry/services/cascade-tweet-search.ts
+++ b/src/registry/services/cascade-tweet-search.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'cascade-tweet-search',
+  providerKey: 'cascade',
+  name: 'Tweet search',
+  endpointUrl: 'https://twitter.surf.cascade.fyi/tweets/search',
+  category: 'Live search',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing Cascade landing page backfilled into the service registry while the public landing page remains coming-soon.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/index.ts
+++ b/src/registry/services/index.ts
@@ -1,0 +1,13 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const serviceModules = import.meta.glob('./*.ts', { eager: true }) as Record<string, { default?: ServiceRegistryEntry }>;
+
+export const serviceRegistryEntries: ServiceRegistryEntry[] = Object.entries(serviceModules)
+  .filter(([path]) => path !== './index.ts')
+  .map(([, module]) => module.default)
+  .filter((service): service is ServiceRegistryEntry => Boolean(service))
+  .sort((a, b) => a.key.localeCompare(b.key));
+
+export const serviceRegistryByKey = Object.fromEntries(
+  serviceRegistryEntries.map((service) => [service.key, service]),
+) as Record<string, ServiceRegistryEntry>;

--- a/src/registry/services/l402-services-predictions-oracle.ts
+++ b/src/registry/services/l402-services-predictions-oracle.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'l402-services-predictions-oracle',
+  providerKey: 'l402-services',
+  name: 'predictions oracle',
+  endpointUrl: 'https://l402.services/predictions/oracle',
+  category: 'Research intelligence',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing live predictions-oracle landing page kept as a legacy-approved service entry.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/llm402-flux-1-schnell-image-generation.ts
+++ b/src/registry/services/llm402-flux-1-schnell-image-generation.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'llm402-flux-1-schnell-image-generation',
+  providerKey: 'llm402',
+  name: 'FLUX.1-schnell image generation',
+  endpointUrl: 'https://llm402.ai/v1/images/generations',
+  category: 'Image generation',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing llm402 image-generation landing page kept as a legacy-approved service entry.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/llm402-gpt-5-image-generation.ts
+++ b/src/registry/services/llm402-gpt-5-image-generation.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'llm402-gpt-5-image-generation',
+  providerKey: 'llm402',
+  name: 'GPT-5-image generation',
+  endpointUrl: 'https://llm402.ai/v1/images/generations',
+  category: 'Image generation',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing llm402 image-generation landing page kept as a legacy-approved service entry.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/payperq-gpt-image-1-5.ts
+++ b/src/registry/services/payperq-gpt-image-1-5.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'payperq-gpt-image-1-5',
+  providerKey: 'payperq',
+  name: 'GPT Image 1.5',
+  endpointUrl: 'https://api.ppq.ai/v1/images/generations/gpt-image-1.5',
+  category: 'Image generation',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing live image-generation landing page kept as a legacy-approved service entry.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/pull-that-up-jamie-search-quotes.ts
+++ b/src/registry/services/pull-that-up-jamie-search-quotes.ts
@@ -1,0 +1,18 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'pull-that-up-jamie-search-quotes',
+  providerKey: 'pull-that-up-jamie',
+  name: 'search-quotes',
+  endpointUrl: 'https://www.pullthatupjamie.ai/api/search-quotes',
+  category: 'Podcast search',
+  reviewStatus: 'approved',
+  reviewSource: 'legacy-manual',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Existing live podcast-quote search landing page kept as a legacy-approved service entry.',
+  notes: ['Backfilled from the current landing-page catalog.'],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/sats4ai-analyze-image.ts
+++ b/src/registry/services/sats4ai-analyze-image.ts
@@ -1,0 +1,21 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'sats4ai-analyze-image',
+  providerKey: 'sats4ai',
+  name: 'analyze-image',
+  endpointUrl: 'https://sats4ai.com/api/l402/analyze-image',
+  category: 'Vision analysis',
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'schema-checked',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Schema was checked directly from the live Sats4AI endpoint, but no paid image-analysis request has been recorded yet.',
+  notes: [
+    'GET schema confirmed image + prompt JSON input.',
+    'Still needs a real paid request before switching the landing page to supported.',
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/sats4ai-convert-html-to-pdf.ts
+++ b/src/registry/services/sats4ai-convert-html-to-pdf.ts
@@ -1,0 +1,21 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'sats4ai-convert-html-to-pdf',
+  providerKey: 'sats4ai',
+  name: 'convert-html-to-pdf',
+  endpointUrl: 'https://sats4ai.com/api/l402/convert-html-to-pdf',
+  category: 'Document conversion',
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'schema-checked',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Schema was checked directly from the live Sats4AI endpoint, but no paid HTML-to-PDF conversion test has been recorded yet.',
+  notes: [
+    'GET schema confirmed support for HTML and Markdown input.',
+    'Still needs a real paid request before switching the landing page to supported.',
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/sats4ai-generate-text.ts
+++ b/src/registry/services/sats4ai-generate-text.ts
@@ -1,0 +1,21 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'sats4ai-generate-text',
+  providerKey: 'sats4ai',
+  name: 'generate-text',
+  endpointUrl: 'https://sats4ai.com/api/l402/generate-text',
+  category: 'Text generation',
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'schema-checked',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Schema was checked directly from the live Sats4AI endpoint, but no paid activation run has been recorded yet.',
+  notes: [
+    'GET schema confirmed the endpoint exists and documents chat-style JSON input.',
+    'Still needs a real paid request before switching the landing page to supported.',
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/sats4ai-translate-text.ts
+++ b/src/registry/services/sats4ai-translate-text.ts
@@ -1,0 +1,21 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'sats4ai-translate-text',
+  providerKey: 'sats4ai',
+  name: 'translate-text',
+  endpointUrl: 'https://sats4ai.com/api/l402/translate-text',
+  category: 'Translation',
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'live',
+  landingPageStatus: 'supported',
+  lastCheckedAt: '2026-04-19',
+  summary: 'Paid-tested Sats4AI translation endpoint with a successful live L402 request and multilingual landing pages already enabled.',
+  notes: [
+    'Successful paid activation test completed on 2026-04-19.',
+    'Real observed cost: 1 sat translation + 1 sat routing fee.',
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,8 +1,16 @@
+export type RegistrySupportStatus = 'supported' | 'coming-soon';
+
 export type ProviderReviewStatus = 'approved' | 'approved-for-trial' | 'rejected' | 'deferred' | 'duplicate';
 
 export type ProviderActivationStatus = 'not-started' | 'tested' | 'live';
 
 export type ProviderReviewSource = 'legacy-manual' | 'manual-intake';
+
+export type ServiceReviewStatus = 'approved' | 'approved-for-trial' | 'rejected' | 'deferred' | 'duplicate';
+
+export type ServiceActivationStatus = 'not-started' | 'schema-checked' | 'paid-tested' | 'live';
+
+export type ServiceReviewSource = 'legacy-manual' | 'manual-intake';
 
 export type ProviderRegistryEntry = {
   key: string;
@@ -13,9 +21,26 @@ export type ProviderRegistryEntry = {
   reviewStatus: ProviderReviewStatus;
   reviewSource: ProviderReviewSource;
   activationStatus: ProviderActivationStatus;
+  lastCheckedAt: string;
   backfilled?: boolean;
   summary: string;
   notes?: string[];
   endpointCandidates?: string[];
+  duplicateOf?: string;
+};
+
+export type ServiceRegistryEntry = {
+  key: string;
+  providerKey: string;
+  name: string;
+  endpointUrl: string;
+  category: string;
+  reviewStatus: ServiceReviewStatus;
+  reviewSource: ServiceReviewSource;
+  activationStatus: ServiceActivationStatus;
+  landingPageStatus: RegistrySupportStatus;
+  lastCheckedAt: string;
+  summary: string;
+  notes?: string[];
   duplicateOf?: string;
 };


### PR DESCRIPTION
## Summary
- add a service registry alongside the provider registry so endpoint-level review and activation status can diverge from provider-level status
- add `lastCheckedAt` fields across provider data, service data, and both registries so review freshness is visible in git
- add more Sats4AI landing pages for `generate-text`, `convert-html-to-pdf`, and `analyze-image`, while keeping only the paid-tested translation endpoint on the supported/install path

## Test Plan
- [x] npm run build
- [x] node scripts/check-provider-registry.mjs
- [x] node scripts/check-service-registry.mjs
- [x] node scripts/check-sats4ai-translation.mjs
- [x] node scripts/check-sats4ai-service-statuses.mjs
- [x] node scripts/check-homepage.mjs
- [x] node scripts/check-route-structure.mjs
- [x] node scripts/check-install-commands.mjs