### PR TITLE
feat: add L402 provider and service intake records

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Expected production URL:
 2. finalize the CTA destination and install UX for supported services
 3. improve SEO metadata per variant, including canonical strategy, Open Graph images, and structured data
 4. keep provider and service registry entries fresh with real last-checked dates as more endpoints are reviewed
-5. add automation that can generate more agent-specific pages from approved provider/service records
-6. add checks for thin or duplicate copy as the number of agents, providers, and services grows
+5. automate repeatable 402index intake runs that refresh provider and representative service registry entries without treating 402index health as the approval gate
+6. add automation that can generate more agent-specific pages from approved provider/service records
+7. add checks for thin or duplicate copy as the number of agents, providers, and services grows
 
 ## Why Astro here
 

--- a/docs/provider-intake-and-activation.md
+++ b/docs/provider-intake-and-activation.md
@@ -31,6 +31,11 @@ For now we only use:
 
 We are **not** scanning Satring, Sponge, x402 Bazaar directly, or other registries yet.
 
+### Health interpretation
+402index health is useful telemetry, but it is **not** the approval gate for provider intake.
+
+Use it to notice possible risk or staleness, but do not reject an otherwise credible provider only because 402index currently reports degraded or down health.
+
 ### Control plane
 We want a provider registry in the repo that records whether a provider is:
 
@@ -138,7 +143,15 @@ Check:
 - GitHub repos
 - whether the provider exposes real discovery docs
 - whether the endpoints issue valid payment challenges
+- whether the service itself is useful enough to justify a landing page
 - any obvious red flags
+
+Important rule:
+
+- **do not use 402index health as the decision gate for provider approval or rejection**
+- record 402index health as telemetry only
+- if a provider looks interesting, evaluate the real site and service directly
+- a provider can still be worth tracking even when 402index currently shows degraded or down health
 
 ### Step 4 — Decide provider status
 Recommended status buckets:
@@ -149,7 +162,15 @@ Recommended status buckets:
 - `rejected`
 - `duplicate`
 
-### Step 5 — Choose only a few endpoints initially
+### Step 5 — Add provider and service registry entries before activation
+For an approved or deferred provider:
+
+- add a provider registry entry with the review decision
+- add 1 representative service registry entry for the best initial endpoint candidate
+- keep service status separate from provider status
+- mark untested endpoints as `activationStatus: not-started` and `landingPageStatus: coming-soon`
+
+### Step 6 — Choose only a few endpoints initially
 Selection criteria:
 
 - cheap to test
@@ -160,7 +181,7 @@ Selection criteria:
 
 Avoid initial activation of expensive, obscure, or highly async endpoints unless necessary.
 
-### Step 6 — Run a real paid test
+### Step 7 — Run a real paid test
 For an approved provider:
 
 - trigger the 402 / L402 challenge
@@ -169,7 +190,7 @@ For an approved provider:
 - save request / response / output artifacts
 - record quirks and pricing
 
-### Step 7 — Only then generate landing page data
+### Step 8 — Only then generate landing page data
 Once the test is real and documented:
 
 - add provider data if needed

--- a/src/registry/providers/402index.ts
+++ b/src/registry/providers/402index.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: '402index',
+  name: "402index",
+  websiteUrl: "https://402index.io",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "402index looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is '402index Services API'.",
+  endpointCandidates: ["services", "export-csv"],
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: tools; average reliability 90.0.",
+    "Representative candidate endpoint: https://402index.io/api/v1/services?l402=require",
+    "Main website candidate: https://402index.io (title: 402 Index)",
+    "Source mix: self-registered\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, mcp, l402, lightning.",
+    "Representative service summary: JSON API for querying indexed L402 and x402 paid API endpoints. Supports filtering by protocol, category, health status, and text search. Free tier with L402 upgrade for higher rate limits.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/a-little-bit-of-money.ts
+++ b/src/registry/providers/a-little-bit-of-money.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'a-little-bit-of-money',
+  name: "A-LITTLE-BIT-OF-MONEY",
+  websiteUrl: "https://alittlebitofmoney.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "A-LITTLE-BIT-OF-MONEY looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'A little bit of money'.",
+  endpointCandidates: ["a-little-bit-of-money"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 78.6.",
+    "Representative candidate endpoint: https://alittlebitofmoney.com/",
+    "Main website candidate: https://alittlebitofmoney.com (title: 402ai.net | Lightning-Native AI Gateway and Task Marketplace)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, l402, lightning.",
+    "Representative service summary: Lightning-paid proxy to AI APIs. Chat completions, image generation, embeddings, audio, video. No account, no API key \u2014 pay per request in sats.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/alex-chen-autopilotai.ts
+++ b/src/registry/providers/alex-chen-autopilotai.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'alex-chen-autopilotai',
+  name: "Alex Chen (AutoPilotAI)",
+  websiteUrl: "https://skillscan.chitacloud.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Alex Chen (AutoPilotAI) looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'SkillScan - AI Agent Security Scanner'.",
+  endpointCandidates: ["skillscan-ai-agent-security-scanner"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 85.0.",
+    "Representative candidate endpoint: https://skillscan.chitacloud.dev/",
+    "Main website candidate: https://skillscan.chitacloud.dev (title: SkillScan - AI Agent Skill Security Scanner)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, contact.",
+    "Representative service summary: Security scanner for AI agent skills and MCP tools. CRITICAL BUG FIXED March 4: now correctly fetches SKILL.md from ClawHub API instead of HTML pages - all scans now accurate. Scans for prompt injection, capability overreach, supply chain r\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/aperezvigoa.ts
+++ b/src/registry/providers/aperezvigoa.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'aperezvigoa',
+  name: "Aperezvigoa",
+  websiteUrl: "https://satsapi.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Aperezvigoa looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'SatsAPI'.",
+  endpointCandidates: ["satsapi"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 85.0.",
+    "Representative candidate endpoint: https://satsapi.dev/",
+    "Main website candidate: https://satsapi.dev.",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Bitcoin market intelligence API with L402 pay-per-call auth. \r\n8 endpoints: price/RSI/MACD, mempool fees, on-chain metrics, \r\nderivatives, AI news sentiment, 9-factor BUY/SELL/HOLD signal \r\nand full market summary. Designed for developers a\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/api-lightningenable-com.ts
+++ b/src/registry/providers/api-lightningenable-com.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'api-lightningenable-com',
+  name: "api.lightningenable.com",
+  websiteUrl: "https://lightningenable.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "api.lightningenable.com appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'lightning-enable',
+  notes: [
+    "402index snapshot on 2026-04-20: 6 indexed L402 services; top categories: tools; average reliability 85.6.",
+    "Representative candidate endpoint: https://app.opennode.com/",
+    "Main website candidate: https://lightningenable.com (title: Lightning Enable - Lightning Payments for AI Agents - Refined Element)",
+    "Source mix: satring\u00d76.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, github, mcp, l402, lightning.",
+    "Representative service summary: [Prerequisites] 1. **OpenNode Account**: Sign up at",
+    "Mapped as duplicate of provider key 'lightning-enable'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/arknode-ai.ts
+++ b/src/registry/providers/arknode-ai.ts
@@ -1,0 +1,28 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'arknode-ai',
+  name: "arknode.ai",
+  websiteUrl: "https://arknode.ai",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "arknode.ai appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'the-ark-ai',
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: tools; average reliability 28.3.",
+    "Representative candidate endpoint: https://arknode.ai/api",
+    "Main website candidate: https://arknode.ai (title: The Ark AI \u2014 Chat with AI, Pay with Lightning \u26a1)",
+    "Source mix: satring\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, contact, lightning.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Mapped as duplicate of provider key 'the-ark-ai'.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/asterpay.ts
+++ b/src/registry/providers/asterpay.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'asterpay',
+  name: "AsterPay",
+  websiteUrl: "https://asterpay.io",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "AsterPay looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'x402.asterpay.io/v1/agent/discovery'.",
+  endpointCandidates: ["discovery", "sentiment", "prices"],
+  notes: [
+    "402index snapshot on 2026-04-20: 4 indexed L402 services; top categories: ai; average reliability 91.2.",
+    "Representative candidate endpoint: https://x402.asterpay.io/v1/agent/discovery",
+    "Main website candidate: https://asterpay.io (title: AsterPay \u2014 Fiat settlement for AI agent commerce | x402 + MPP \u00b7 SEPA Instant)",
+    "Source mix: satring\u00d74.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, github, mcp.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/bitcoin-benji.ts
+++ b/src/registry/providers/bitcoin-benji.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'bitcoin-benji',
+  name: "Bitcoin Benji",
+  websiteUrl: "https://bitcoinbenji.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Bitcoin Benji looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Bitcoin Benji API \u2014 Mempool Intelligence + AI Utilities'.",
+  endpointCandidates: ["bitcoin-benji-api-mempool-intelligence-ai-utilities", "whales", "agent"],
+  notes: [
+    "402index snapshot on 2026-04-20: 17 indexed L402 services; top categories: ai, bitcoin; average reliability 90.0.",
+    "Representative candidate endpoint: https://ovz5i27at6cjnfz2mhenkhsxqgwjh4rpkyju5ctr6xgju2hdklsfbpqd.onion/",
+    "Main website candidate: https://bitcoinbenji.com (title: Bitcoin Benji API - Lightning-Native Machine Intelligence)",
+    "Source mix: self-registered\u00d716, satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: contact, l402, lightning.",
+    "Representative service summary: 16 paid L402 endpoints: Bitcoin mempool intelligence (fee estimates, whale alerts, mempool state, block data) + 11 AI utility APIs (summarize, sentiment, translate, grammar, code-review, extract, scrape, agent, classify, rewrite, explain). \u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/bmur.ts
+++ b/src/registry/providers/bmur.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'bmur',
+  name: "Bmur",
+  websiteUrl: "https://ganamos.earth",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Bmur appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'ganamos',
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: social, tools; average reliability 100.0.",
+    "Representative candidate endpoint: https://speedread.fit/",
+    "Main website candidate: https://ganamos.earth (title: Ganamos! Bitcoin-Powered Job Marketplace)",
+    "Source mix: satring\u00d71, satring,l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, l402, lightning.",
+    "Representative service summary: Speed reading app using RSVP technology. Upload PDFs, paste text, or read web articles at high speed. Browse a public library of documents with optional L402 paywalls \u2014 payments go directly to content creators via their Lightning Address.",
+    "Mapped as duplicate of provider key 'ganamos'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/boltwork.ts
+++ b/src/registry/providers/boltwork.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'boltwork',
+  name: "Boltwork",
+  websiteUrl: "https://parsebit-lnd.fly.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Boltwork looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Boltwork Web Page Summariser'.",
+  endpointCandidates: ["webpage", "translate", "data"],
+  notes: [
+    "402index snapshot on 2026-04-20: 10 indexed L402 services; top categories: ai; average reliability 100.0.",
+    "Representative candidate endpoint: https://parsebit-lnd.fly.dev/extract/webpage",
+    "Main website candidate: https://parsebit-lnd.fly.dev.",
+    "Source mix: self-registered\u00d710.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Submit any web page URL and receive a structured AI summary including title, key points, topics, and sentiment. Powered by Claude. Pay 100 sats per request via Bitcoin Lightning L402.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/ca3b1476dc28f4-lhr-life.ts
+++ b/src/registry/providers/ca3b1476dc28f4-lhr-life.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'ca3b1476dc28f4-lhr-life',
+  name: "ca3b1476dc28f4.lhr.life",
+  websiteUrl: "https://ca3b1476dc28f4.lhr.life",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "ca3b1476dc28f4.lhr.life is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: uncategorized; average reliability 30.0.",
+    "Representative candidate endpoint: https://ca3b1476dc28f4.lhr.life/encode",
+    "Main website candidate: https://ca3b1476dc28f4.lhr.life.",
+    "Source mix: l402apps\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: L402-protected encode utility service - 5 sats per request",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/cabal.ts
+++ b/src/registry/providers/cabal.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'cabal',
+  name: "Cabal",
+  websiteUrl: "https://getcabal.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Cabal looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Cabal: getcabal.com API'.",
+  endpointCandidates: ["connectors", "to-company", "to-person"],
+  notes: [
+    "402index snapshot on 2026-04-20: 5 indexed L402 services; top categories: uncategorized; average reliability 95.0.",
+    "Representative candidate endpoint: https://getcabal.com/api/agent_api/v1/connectors",
+    "Main website candidate: https://getcabal.com (title: Cabal \u2014 AI-Powered Relationship Intelligence)",
+    "Source mix: l402apps\u00d75.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, github, mcp.",
+    "Representative service summary: Get list of advisors and connectors in your network who can make introductions",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/catalunyalnd.ts
+++ b/src/registry/providers/catalunyalnd.ts
@@ -1,0 +1,24 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'catalunyalnd',
+  name: "CatalunyaLND",
+  websiteUrl: "https://l402-fortune-cookie.yf-ae7.workers.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "CatalunyaLND appears real enough to keep on the radar, but it is not yet one of the highest-priority providers for landing-page work.",
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: tools; average reliability 85.0.",
+    "Representative candidate endpoint: https://l402-fortune-cookie.yf-ae7.workers.dev/api/fortune",
+    "Main website candidate: https://l402-fortune-cookie.yf-ae7.workers.dev.",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Get a random fortune cookie wisdom for 1 sat. Minimal L402 demo API powered by Cloudflare Workers + LNbits.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/claudio-ai-agent.ts
+++ b/src/registry/providers/claudio-ai-agent.ts
@@ -1,0 +1,24 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'claudio-ai-agent',
+  name: "Claudio (AI Agent)",
+  websiteUrl: "https://oracle.neofreight.net",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Claudio (AI Agent) appears real enough to keep on the radar, but it is not yet one of the highest-priority providers for landing-page work.",
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: real-time-data; average reliability 100.0.",
+    "Representative candidate endpoint: https://oracle.neofreight.net/",
+    "Main website candidate: https://oracle.neofreight.net.",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Verify Bitcoin transactions, addresses, and invoices. Get fee estimates, block height, and BTC/USD price with Nostr-signed attestation. Real mainnet node. 21 sats/request via L402.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/d7c48175b848df-lhr-life.ts
+++ b/src/registry/providers/d7c48175b848df-lhr-life.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'd7c48175b848df-lhr-life',
+  name: "d7c48175b848df.lhr.life",
+  websiteUrl: "https://d7c48175b848df.lhr.life",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "d7c48175b848df.lhr.life is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: uncategorized; average reliability 30.0.",
+    "Representative candidate endpoint: https://d7c48175b848df.lhr.life/password",
+    "Main website candidate: https://d7c48175b848df.lhr.life.",
+    "Source mix: l402apps\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: L402 password utility",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/derek-by-fr0zen-btc.ts
+++ b/src/registry/providers/derek-by-fr0zen-btc.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'derek-by-fr0zen-btc',
+  name: "Derek by Fr0zen_BTC",
+  websiteUrl: "https://tooth-therapeutic-bias-exclude.trycloudflare.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Derek by Fr0zen_BTC is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: real-time-data; average reliability 30.0.",
+    "Representative candidate endpoint: https://tooth-therapeutic-bias-exclude.trycloudflare.com/api/latest-alert",
+    "Main website candidate: https://tooth-therapeutic-bias-exclude.trycloudflare.com.",
+    "Source mix: l402directory\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Latest breaking Bitcoin alert. Only issued for 3%+ BTC moves or fundamental shifts (exchange hacks, regulatory moves, ETF decisions, sovereign purchases). Updated every 15 minutes.",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/djd-agent-score.ts
+++ b/src/registry/providers/djd-agent-score.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'djd-agent-score',
+  name: "DJD Agent Score",
+  websiteUrl: "https://djdagentscore.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "DJD Agent Score looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'djdagentscore.dev/v1/certification/apply'.",
+  endpointCandidates: ["apply", "timeline"],
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: ai; average reliability 95.0.",
+    "Representative candidate endpoint: https://djdagentscore.dev/v1/certification/apply",
+    "Main website candidate: https://djdagentscore.dev (title: DJD Agent Score \u2014 Wallet Risk API for Paid Agent Workflows)",
+    "Source mix: satring\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, github, mcp.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/e67f2b513f5224-lhr-life.ts
+++ b/src/registry/providers/e67f2b513f5224-lhr-life.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'e67f2b513f5224-lhr-life',
+  name: "e67f2b513f5224.lhr.life",
+  websiteUrl: "https://e67f2b513f5224.lhr.life",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "e67f2b513f5224.lhr.life is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: ai; average reliability 30.0.",
+    "Representative candidate endpoint: https://e67f2b513f5224.lhr.life/analyze",
+    "Main website candidate: https://e67f2b513f5224.lhr.life.",
+    "Source mix: l402apps\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Gary AI Text Analysis - AI-powered text analysis and NLP service. Pay 5 sats per request. Returns word count, sentiment, reading level, and more.",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/einstein-ai.ts
+++ b/src/registry/providers/einstein-ai.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'einstein-ai',
+  name: "Einstein AI",
+  websiteUrl: "https://emc2ai.io",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Einstein AI looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'emc2ai.io/x402/bitquery/arbitragescanner'.",
+  endpointCandidates: ["arbitragescanner", "bscalpha", "dexcapital"],
+  notes: [
+    "402index snapshot on 2026-04-20: 25 indexed L402 services; top categories: ai; average reliability 94.9.",
+    "Representative candidate endpoint: https://emc2ai.io/x402/bitquery/arbitragescanner",
+    "Main website candidate: https://emc2ai.io (title: Einstein-Client)",
+    "Source mix: satring\u00d725.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/fewsats.ts
+++ b/src/registry/providers/fewsats.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'fewsats',
+  name: "Fewsats",
+  websiteUrl: "https://fewsats.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Fewsats looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Fewsats'.",
+  endpointCandidates: ["fewsats"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: crypto; average reliability 100.0.",
+    "Representative candidate endpoint: https://fewsats.com/",
+    "Main website candidate: https://fewsats.com.",
+    "Source mix: l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Payment infrastructure for AI agents. Enables autonomous agents to pay and get paid using L402.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/ganamos.ts
+++ b/src/registry/providers/ganamos.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'ganamos',
+  name: "Ganamos",
+  websiteUrl: "https://ganamos.earth",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Ganamos looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Ganamos: Create Job'.",
+  endpointCandidates: ["posts", "fixes"],
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: tools, bitcoin; average reliability 93.3.",
+    "Representative candidate endpoint: https://www.ganamos.earth/api/posts",
+    "Main website candidate: https://ganamos.earth (title: Ganamos! Bitcoin-Powered Job Marketplace)",
+    "Source mix: discovery\u00d72, l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, l402, lightning.",
+    "Representative service summary: Post a Bitcoin-funded bounty job. Costs reward amount + 10 sat API fee via L402 Lightning payment. Returns post_id and status URL.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/golem-gateway.ts
+++ b/src/registry/providers/golem-gateway.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'golem-gateway',
+  name: "golem-gateway",
+  websiteUrl: "https://atlas.tail33dea9.ts.net",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "golem-gateway is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 30.0.",
+    "Representative candidate endpoint: https://atlas.tail33dea9.ts.net/",
+    "Main website candidate: https://atlas.tail33dea9.ts.net.",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Ollama \u2014 qwen2.5:3b",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/governance-taskhawktech-com.ts
+++ b/src/registry/providers/governance-taskhawktech-com.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'governance-taskhawktech-com',
+  name: "governance.taskhawktech.com",
+  websiteUrl: "https://governance.taskhawktech.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "governance.taskhawktech.com appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'taskhawk-systems',
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: tools; average reliability 90.0.",
+    "Representative candidate endpoint: https://governance.taskhawktech.com/governance/batch",
+    "Main website candidate: https://governance.taskhawktech.com.",
+    "Source mix: self-registered,l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Batch governance operations - multiple verify/attest/bind in one call. lnget compatible.",
+    "Mapped as duplicate of provider key 'taskhawk-systems'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/hyperdope-com.ts
+++ b/src/registry/providers/hyperdope-com.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'hyperdope-com',
+  name: "hyperdope.com",
+  websiteUrl: "https://hyperdope.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "hyperdope.com appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'hyperdope',
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: bitcoin; average reliability 90.0.",
+    "Representative candidate endpoint: https://hyperdope.com/api/l402/videos/17c27b50/master.m3u8",
+    "Main website candidate: https://hyperdope.com (title: Hyperdope)",
+    "Source mix: self-registered,l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, l402, lightning.",
+    "Representative service summary: L402-gated HLS video streaming. 10 sats for 4 hours of access. Returns HLS master playlist. Browse videos at hyperdope.com/api/homepage, search at hyperdope.com/api/search?q=bitcoin. Play in browser via hyperdope.com/player.html?v={hash}&to\u2026",
+    "Mapped as duplicate of provider key 'hyperdope'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/hyperdope.ts
+++ b/src/registry/providers/hyperdope.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'hyperdope',
+  name: "Hyperdope",
+  websiteUrl: "https://l402.services",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Hyperdope looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Lightning Fee Oracle'.",
+  endpointCandidates: ["fees", "oracle", "suggest"],
+  notes: [
+    "402index snapshot on 2026-04-20: 10 indexed L402 services; top categories: data, real-time-data, ai; average reliability 81.8.",
+    "Representative candidate endpoint: https://l402.services/ln/fees",
+    "Main website candidate: https://l402.services.",
+    "Source mix: l402directory,l402apps\u00d73, l402directory\u00d76, satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Fee oracle \u2014 network-wide fee distribution percentiles, daily fee change trends, volatility metrics. Optional ?pubkey= for per-node detail, ?days= for window",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/l402-apps.ts
+++ b/src/registry/providers/l402-apps.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'l402-apps',
+  name: "L402 Apps",
+  websiteUrl: "https://l402apps.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "L402 Apps looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'L402 Apps: Lightning Lottery'.",
+  endpointCandidates: ["enter", "api-submissions", "apis"],
+  notes: [
+    "402index snapshot on 2026-04-20: 6 indexed L402 services; top categories: tools, bitcoin, uncategorized; average reliability 90.0.",
+    "Representative candidate endpoint: https://www.l402apps.com/api/lottery/enter",
+    "Main website candidate: https://l402apps.com (title: L402 Apps)",
+    "Source mix: l402apps\u00d76.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, l402, lightning.",
+    "Representative service summary: Enter the 24h Lightning Lottery. More sats = higher winning probability. Provide a Lightning Address or node pubkey for payout.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/lightning-enable.ts
+++ b/src/registry/providers/lightning-enable.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'lightning-enable',
+  name: "Lightning Enable",
+  websiteUrl: "https://lightningenable.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Lightning Enable looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Agent Commerce Store'.",
+  endpointCandidates: ["agent-commerce-store", "reputation", "ping"],
+  notes: [
+    "402index snapshot on 2026-04-20: 40 indexed L402 services; top categories: data, guides, commerce; average reliability 89.1.",
+    "Representative candidate endpoint: https://agent-commerce.store/",
+    "Main website candidate: https://lightningenable.com (title: Lightning Enable - Lightning Payments for AI Agents - Refined Element)",
+    "Source mix: self-registered\u00d737, discovery\u00d71, satring\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, github, mcp, l402, lightning.",
+    "Representative service summary: 13 L402-gated API endpoints for AI agents. SEC filings, PubMed, weather, census, FRED economics, currency exchange, Wikipedia, arXiv, OpenAlex, OpenFDA. 1-10 sats per call. No API keys. Payment is authentication.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/lightning-faucet.ts
+++ b/src/registry/providers/lightning-faucet.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'lightning-faucet',
+  name: "Lightning Faucet",
+  websiteUrl: "https://lightningfaucet.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Lightning Faucet looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Lightning Faucet: Profanity Filter'.",
+  endpointCandidates: ["profanity-filter", "llm-prompt", "invoice-decode"],
+  notes: [
+    "402index snapshot on 2026-04-20: 25 indexed L402 services; top categories: uncategorized, tools, real-time-data; average reliability 88.7.",
+    "Representative candidate endpoint: https://lightningfaucet.com/api/l402/profanity_filter",
+    "Main website candidate: https://lightningfaucet.com (title: Lightning Faucet - Free Bitcoin on Lightning Network)",
+    "Source mix: satring\u00d72, satring,l402apps\u00d721, l402apps\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, terms, contact, l402, lightning.",
+    "Representative service summary: Content moderation API. Detect and filter profanity in text. Returns flagged words and clean version. 10 sats per request.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/lightningfaucet-com.ts
+++ b/src/registry/providers/lightningfaucet-com.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'lightningfaucet-com',
+  name: "lightningfaucet.com",
+  websiteUrl: "https://lightningfaucet.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "lightningfaucet.com appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'lightning-faucet',
+  notes: [
+    "402index snapshot on 2026-04-20: 10 indexed L402 services; top categories: bitcoin, ai, tools; average reliability 90.3.",
+    "Representative candidate endpoint: https://lightningfaucet.com/api/l402/profanity-filter",
+    "Main website candidate: https://lightningfaucet.com (title: Lightning Faucet - Free Bitcoin on Lightning Network)",
+    "Source mix: l402apps\u00d710.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, terms, contact, l402, lightning.",
+    "Representative service summary: Lightning Faucet Profanity Filter (detect, 10 sats)",
+    "Mapped as duplicate of provider key 'lightning-faucet'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/lpx-digital-group-llc.ts
+++ b/src/registry/providers/lpx-digital-group-llc.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'lpx-digital-group-llc',
+  name: "LPX Digital Group LLC",
+  websiteUrl: "https://aiprox.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "LPX Digital Group LLC looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'LightningProx \u2014 Multi-Model AI Gateway'.",
+  endpointCandidates: ["messages", "orchestrate"],
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: ai; average reliability 90.0.",
+    "Representative candidate endpoint: https://lightningprox.com/v1/messages",
+    "Main website candidate: https://aiprox.dev (title: AIProx \u2014 The Agent Discovery & Payment Layer)",
+    "Source mix: self-registered\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, l402, lightning.",
+    "Representative service summary: Pay-per-request AI inference via Bitcoin Lightning L402. 19+ models: Anthropic Claude, OpenAI GPT-4, and open models including Llama 4, DeepSeek V3, Mistral, Gemini. No accounts, no API keys. Drop-in OpenAI SDK replacement. Inline L402 chal\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/lpx-digital-group.ts
+++ b/src/registry/providers/lpx-digital-group.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'lpx-digital-group',
+  name: "LPX Digital Group",
+  websiteUrl: "https://isitarug.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "LPX Digital Group looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'IsItARug'.",
+  endpointCandidates: ["isitarug"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 80.0.",
+    "Representative candidate endpoint: https://isitarug.com/",
+    "Main website candidate: https://isitarug.com (title: Is It A Rug? \u2014 Solana Token Scanner)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, lightning.",
+    "Representative service summary: Solana token safety scanner. Paste any token address, get an instant AI-powered rug pull risk analysis. Pay 10 sats per scan via Lightning. No signup required.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/maximum-sats.ts
+++ b/src/registry/providers/maximum-sats.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'maximum-sats',
+  name: "Maximum Sats",
+  websiteUrl: "https://maximumsats.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Maximum Sats appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'maximumsats',
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: identity; average reliability 95.0.",
+    "Representative candidate endpoint: https://maximumsats.com/",
+    "Main website candidate: https://maximumsats.com (title: Developer Tools for the Lightning Network | Maximum Sats)",
+    "Source mix: l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: pricing, terms, github, l402, lightning.",
+    "Representative service summary: Bitcoin tools and APIs powered by Lightning Network. AI, Web of Trust scoring, Nostr summaries. Pay per request via L402.",
+    "Mapped as duplicate of provider key 'maximumsats'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/maximumsats.ts
+++ b/src/registry/providers/maximumsats.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'maximumsats',
+  name: "MaximumSats",
+  websiteUrl: "https://maximumsats.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "MaximumSats looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'AI DVM'.",
+  endpointCandidates: ["dvm", "nostr-id-inspect", "wot-report"],
+  notes: [
+    "402index snapshot on 2026-04-20: 50 indexed L402 services; top categories: bitcoin, nostr, lightning; average reliability 45.9.",
+    "Representative candidate endpoint: https://maximumsats.com/api/dvm",
+    "Main website candidate: https://maximumsats.com (title: Developer Tools for the Lightning Network | Maximum Sats)",
+    "Source mix: discovery\u00d750.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: pricing, terms, github, l402, lightning.",
+    "Representative service summary: General-purpose AI assistant via DVM (Data Vending Machine). Free tier: 1 query/24h, then L402. Also supports x402 (USDC).",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/minifetch.ts
+++ b/src/registry/providers/minifetch.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'minifetch',
+  name: "Minifetch",
+  websiteUrl: "https://minifetch.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Minifetch looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'minifetch.com/api/v1/x402/extract/url-content'.",
+  endpointCandidates: ["url-content", "url-links", "url-metadata"],
+  notes: [
+    "402index snapshot on 2026-04-20: 4 indexed L402 services; top categories: real-time-data; average reliability 95.0.",
+    "Representative candidate endpoint: https://minifetch.com/api/v1/x402/extract/url-content",
+    "Main website candidate: https://minifetch.com (title: Minifetch.com: Fetch & extract metadata and data from web pages. For SEO research and AI projects.)",
+    "Source mix: satring\u00d74.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, terms, contact, github.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/moltalyzer.ts
+++ b/src/registry/providers/moltalyzer.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'moltalyzer',
+  name: "Moltalyzer",
+  websiteUrl: "https://moltalyzer.xyz",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Moltalyzer looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'api.moltalyzer.xyz/api/github/digests'.",
+  endpointCandidates: ["digests", "latest", "repos"],
+  notes: [
+    "402index snapshot on 2026-04-20: 10 indexed L402 services; top categories: ai; average reliability 93.0.",
+    "Representative candidate endpoint: https://api.moltalyzer.xyz/api/github/digests",
+    "Main website candidate: https://moltalyzer.xyz (title: Moltalyzer - Viral Advisor &amp; Intelligence API for AI Agents)",
+    "Source mix: satring\u00d710.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, github, mcp.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/mutinywallet.ts
+++ b/src/registry/providers/mutinywallet.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'mutinywallet',
+  name: "MutinyWallet",
+  websiteUrl: "https://faucet.mutinynet.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "MutinyWallet looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Mutinynet Faucet'.",
+  endpointCandidates: ["l402"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: bitcoin; average reliability 95.0.",
+    "Representative candidate endpoint: https://faucet.mutinynet.com/api/l402",
+    "Main website candidate: https://faucet.mutinynet.com.",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: github, lightning.",
+    "Representative service summary: Lightning-gated faucet on Bitcoin's Mutinynet testnet. Pay a small L402 invoice to receive testnet sats.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/mycelia-signal.ts
+++ b/src/registry/providers/mycelia-signal.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'mycelia-signal',
+  name: "Mycelia Signal",
+  websiteUrl: "https://myceliasignal.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Mycelia Signal looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Mycelia Signal DLC Threshold Oracle'.",
+  endpointCandidates: ["threshold", "vwap", "price"],
+  notes: [
+    "402index snapshot on 2026-04-20: 13 indexed L402 services; top categories: real-time-data, data, uncategorized; average reliability 95.4.",
+    "Representative candidate endpoint: https://api.myceliasignal.com/dlc/oracle/threshold",
+    "Main website candidate: https://myceliasignal.com (title: Mycelia Signal \u2014 Sovereign Oracle | Signed Price Data over Lightning & x402)",
+    "Source mix: satring\u00d711, discovery\u00d71, self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, github, mcp, l402, lightning.",
+    "Representative service summary: Register a DLC threshold contract (pair, strike, direction ABOVE/BELOW, expiry Unix timestamp). Schnorr attestation over secp256k1 for Bitcoin smart contract settlement. Free testnet available at /dlc/oracle/threshold/preview.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/open-agents.ts
+++ b/src/registry/providers/open-agents.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'open-agents',
+  name: "Open Agents",
+  websiteUrl: "https://openagents.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Open Agents looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Open Agents'.",
+  endpointCandidates: ["open-agents"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: tools; average reliability 95.0.",
+    "Representative candidate endpoint: https://openagents.com/",
+    "Main website candidate: https://openagents.com (title: openagents.com)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: An open platform for AI agents, built in public from scratch.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/paul.ts
+++ b/src/registry/providers/paul.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'paul',
+  name: "Paul",
+  websiteUrl: "https://certvera.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Paul looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'CertVera Update Notifications'.",
+  endpointCandidates: ["l402"],
+  notes: [
+    "402index snapshot on 2026-04-20: 5 indexed L402 services; top categories: identity; average reliability 80.0.",
+    "Representative candidate endpoint: https://certvera.com/api/l402?action=l402_timestamp_update",
+    "Main website candidate: https://certvera.com (title: CertVera - Blockchain Document Certification)",
+    "Source mix: satring\u00d75.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, terms, contact, l402, lightning.",
+    "Representative service summary: Update webhook and email notification settings on an existing Bitcoin timestamp. POST {action: l402_timestamp_update, timestamp_id: <id>, webhook_url: <url>, notification_email: <email>} to certvera.com/api/l402. 10 sats via L402. Modify no\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/plebtv.ts
+++ b/src/registry/providers/plebtv.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'plebtv',
+  name: "PlebTV",
+  websiteUrl: "https://plebtv.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "PlebTV looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'PlebTV: Integrating Bitcoin Payments with the Zaprite API | Live Coding Workshop with NickTee'.",
+  endpointCandidates: ["integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee-jyd0ko", "pleblabhackathons-sats-4-tips-accepting-tips-in-sats-for-restaurants-donation-pages-charities-and-anyone-working-auduz0", "pbs-live-pbs-3-moonbase-v-california-gurls-30min-wait-massages-w-thomas-johns-simon-logan-l1gy7l"],
+  notes: [
+    "402index snapshot on 2026-04-20: 37 indexed L402 services; top categories: video, technology, education; average reliability 45.2.",
+    "Representative candidate endpoint: https://www.plebtv.com/api/l402/video/integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee-jyd0ko",
+    "Main website candidate: https://plebtv.com (title: PlebTV)",
+    "Source mix: self-registered\u00d737.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: pricing, lightning.",
+    "Representative service summary: NickTee dives into the Zaprite API your gateway to Bitcoin-native invoicing, payment processing, and financial automation. Whether you're building client apps, hacking on side projects, or just exploring how to integrate Lightning and on-ch\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/prime-technology.ts
+++ b/src/registry/providers/prime-technology.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'prime-technology',
+  name: "Prime Technology",
+  websiteUrl: "https://grid.ptsolutions.io",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Prime Technology looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'U.S. Grid \u2014 Cheapest Electricity Zones'.",
+  endpointCandidates: ["cheapest", "ercot", "caiso"],
+  notes: [
+    "402index snapshot on 2026-04-20: 74 indexed L402 services; top categories: energy, real-time-data; average reliability 87.5.",
+    "Representative candidate endpoint: https://grid.ptsolutions.io/v1/cheapest",
+    "Main website candidate: https://grid.ptsolutions.io (title: Grid Energy API \u2014 Real-Time U.S. Electricity Prices)",
+    "Source mix: self-registered\u00d774.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, l402, lightning.",
+    "Representative service summary: Top N cheapest electricity pricing zones right now across all 8 U.S. ISOs: ERCOT, CAISO, MISO, NYISO, ISONE, SPP, WEIM, SPP_WEIS. Ranked by current LMP. Pass ?limit=N to control result count. Ideal for Bitcoin miners and data center operato\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/proxy402.ts
+++ b/src/registry/providers/proxy402.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'proxy402',
+  name: "proxy402",
+  websiteUrl: "https://proxy402.fun",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "proxy402 looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'proxy402: Chat Completions (348 models)'.",
+  endpointCandidates: ["completions"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 90.0.",
+    "Representative candidate endpoint: https://api.proxy402.fun/v1/chat/completions",
+    "Main website candidate: https://proxy402.fun (title: proxy402.fun \u2014 Lightning-native AI inference for autonomous agents)",
+    "Source mix: discovery\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: pricing, github, l402, lightning.",
+    "Representative service summary: OpenAI-compatible chat completions API proxying 348+ models via OpenRouter. Pay-per-request with Lightning. Supports GPT, Claude, Mistral, Grok, Gemini, and more. No account required.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/rob.ts
+++ b/src/registry/providers/rob.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'rob',
+  name: "rob",
+  websiteUrl: "https://botlab.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "rob appears real enough to keep on the radar, but it is not yet one of the highest-priority providers for landing-page work.",
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 80.0.",
+    "Representative candidate endpoint: https://botlab.dev/api/web-search",
+    "Main website candidate: https://botlab.dev (title: botlab.dev | Custom AI/LLM Bots, Agents, Swarms, Automation)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: contact, github, l402, lightning.",
+    "Representative service summary: AI-powered web search. Returns a synthesized, cited answer from Brave Search results using Gemini 3 Flash \u2014 not just links. Supports GET and POST, responds with structured JSON. No API keys or accounts needed.\nTiers: [100 sats: 2,500 tokens\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/robtex.ts
+++ b/src/registry/providers/robtex.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'robtex',
+  name: "Robtex",
+  websiteUrl: "https://robtex.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Robtex looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'x402.robtex.com/api/v1/as_info'.",
+  endpointCandidates: ["as-info", "as-prefixes", "asquery"],
+  notes: [
+    "402index snapshot on 2026-04-20: 57 indexed L402 services; top categories: tools, real-time-data, uncategorized; average reliability 100.0.",
+    "Representative candidate endpoint: https://x402.robtex.com/api/v1/as_info",
+    "Main website candidate: https://robtex.com (title: Robtex - Free DNS Lookup & Network Intelligence)",
+    "Source mix: satring\u00d757.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, contact, mcp, lightning.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/satoshi-dispatches-mystere-me.ts
+++ b/src/registry/providers/satoshi-dispatches-mystere-me.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'satoshi-dispatches-mystere-me',
+  name: "Satoshi (dispatches.mystere.me)",
+  websiteUrl: "https://dispatches.mystere.me",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Satoshi (dispatches.mystere.me) appears real enough to keep on the radar, but it is not yet one of the highest-priority providers for landing-page work.",
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 87.3.",
+    "Representative candidate endpoint: https://dispatches.mystere.me/dispatch/002",
+    "Main website candidate: https://dispatches.mystere.me (title: Satoshi Dispatches \u26a1)",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, l402, lightning.",
+    "Representative service summary: 45 dispatches from an autonomous AI agent running a mainnet Lightning node on a Raspberry Pi. Pay per dispatch, 10 sats. #001 free. Ask Satoshi at /ask \u2014 100 sats/question, agent-answered. lnget-compatible. L402 macaroon + BOLT11 invoice on\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/satring.ts
+++ b/src/registry/providers/satring.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'satring',
+  name: "Satring",
+  websiteUrl: "https://satring.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Satring looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Satring Directory API'.",
+  endpointCandidates: ["services", "search", "services-bulk"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: real-time-data; average reliability 85.0.",
+    "Representative candidate endpoint: https://satring.com/api/v1/services",
+    "Main website candidate: https://satring.com (title: Stats | Curated Paid API Directory for AI Agents)",
+    "Source mix: satring,l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, contact, github, mcp, l402, lightning.",
+    "Representative service summary: L402 + x402 paid API directory. GET for paginated listing with category/protocol filters, detail by slug, and search. POST to submit new services (1000 sats / $0.50 USDC). PATCH to edit with token.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/satsback-com.ts
+++ b/src/registry/providers/satsback-com.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'satsback-com',
+  name: "Satsback.com",
+  websiteUrl: "https://satsback.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Satsback.com looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Satsback Agent API'.",
+  endpointCandidates: ["register"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: earn; average reliability 97.0.",
+    "Representative candidate endpoint: https://satsback.com/api/v2/l402/register",
+    "Main website candidate: https://satsback.com.",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, lightning.",
+    "Representative service summary: Cashback infrastructure for AI agents, settled in sats. Browse 10,000+ online retailers, generate affiliate-tracked links, and route Bitcoin payouts directly to Lightning addresses. L402-gated API with full MCP server support \u2014 built for ag\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/satwork.ts
+++ b/src/registry/providers/satwork.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'satwork',
+  name: "satwork",
+  websiteUrl: "https://satwork.ai",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "satwork looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'satwork: Earn sats \u2014 optimization bounties for AI agents'.",
+  endpointCandidates: ["targets"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: earn; average reliability 95.0.",
+    "Representative candidate endpoint: https://satwork.ai/api/l402/targets",
+    "Main website candidate: https://satwork.ai (title: satwork &mdash; Sats for Work. Work for Sats.)",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, lightning.",
+    "Representative service summary: The first earn service on 402index. AI agents arrive with zero sats and start earning immediately \u2014 no account, no API key, no signup. Propose parameter optimizations (2 sats/attempt), get scored deterministically in a sandbox, earn 50-500 \u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/semagram-io.ts
+++ b/src/registry/providers/semagram-io.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'semagram-io',
+  name: "semagram.io",
+  websiteUrl: "https://semagram.io",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "semagram.io looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'semagram.io: Semantic search API for Telegram. Search across 1M channels, 150K chats, and 100K bots using hybrid search (embedding similarity + BM25 keyword matches).'.",
+  endpointCandidates: ["search"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 100.0.",
+    "Representative candidate endpoint: https://semagram.io/api/agent/search",
+    "Main website candidate: https://semagram.io (title: Semagram)",
+    "Source mix: l402apps\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: contact.",
+    "Representative service summary: Semantic search API for Telegram. Search across 1M channels, 150K chats, and 100K bots using hybrid search (embedding similarity + BM25 keyword matches).",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/sociologic.ts
+++ b/src/registry/providers/sociologic.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'sociologic',
+  name: "SocioLogic",
+  websiteUrl: "https://rng.sociologic.ai",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "SocioLogic looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'rng.sociologic.ai/random'.",
+  endpointCandidates: ["random", "uuid"],
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: ai; average reliability 94.7.",
+    "Representative candidate endpoint: https://rng.sociologic.ai/random",
+    "Main website candidate: https://rng.sociologic.ai.",
+    "Source mix: satring\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/spark.ts
+++ b/src/registry/providers/spark.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'spark',
+  name: "Spark",
+  websiteUrl: "https://l402.lndyn.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Spark looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Mempool Fee Estimates'.",
+  endpointCandidates: ["mempool-fees", "nostr-trending", "quote"],
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: bitcoin, social; average reliability 87.9.",
+    "Representative candidate endpoint: https://l402.lndyn.com/api/mempool-fees",
+    "Main website candidate: https://l402.lndyn.com (title: Spark L402 API)",
+    "Source mix: self-registered\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, l402, lightning.",
+    "Representative service summary: Real-time Bitcoin mempool fee estimates (sat/vB) for next block, ~10min, ~30min targets",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/stabletravel-dev.ts
+++ b/src/registry/providers/stabletravel-dev.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'stabletravel-dev',
+  name: "stabletravel.dev",
+  websiteUrl: "https://stabletravel.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "stabletravel.dev looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'stabletravel.dev/api/reference/airline-routes'.",
+  endpointCandidates: ["airline-routes"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: tools; average reliability 95.0.",
+    "Representative candidate endpoint: https://stabletravel.dev/api/reference/airline-routes",
+    "Main website candidate: https://stabletravel.dev (title: StableTravel)",
+    "Source mix: satring\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, terms.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/stableupload.ts
+++ b/src/registry/providers/stableupload.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'stableupload',
+  name: "StableUpload",
+  websiteUrl: "https://stableupload.dev",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "StableUpload looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'stableupload.dev/api/site'.",
+  endpointCandidates: ["site", "activate", "domain"],
+  notes: [
+    "402index snapshot on 2026-04-20: 8 indexed L402 services; top categories: storage, crypto; average reliability 93.1.",
+    "Representative candidate endpoint: https://stableupload.dev/api/site",
+    "Main website candidate: https://stableupload.dev (title: StableUpload)",
+    "Source mix: satring\u00d78.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, terms.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/taskhawk-systems.ts
+++ b/src/registry/providers/taskhawk-systems.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'taskhawk-systems',
+  name: "TaskHawk Systems",
+  websiteUrl: "https://governance.taskhawktech.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "TaskHawk Systems looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Kevros Governance Verify'.",
+  endpointCandidates: ["verify", "attest"],
+  notes: [
+    "402index snapshot on 2026-04-20: 6 indexed L402 services; top categories: ai, media; average reliability 90.0.",
+    "Representative candidate endpoint: https://governance.taskhawktech.com/governance/verify",
+    "Main website candidate: https://governance.taskhawktech.com.",
+    "Source mix: satring,l402apps\u00d75, self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Runtime intelligence action verification with signed ALLOW/CLAMP/DENY decision",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/the-ark-ai.ts
+++ b/src/registry/providers/the-ark-ai.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'the-ark-ai',
+  name: "The Ark AI",
+  websiteUrl: "https://arknode.ai",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "The Ark AI looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'The Ark AI: Multi-Tool L402 Gateway'.",
+  endpointCandidates: ["task"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: ai; average reliability 20.0.",
+    "Representative candidate endpoint: https://arknode.ai/l402/task",
+    "Main website candidate: https://arknode.ai (title: The Ark AI \u2014 Chat with AI, Pay with Lightning \u26a1)",
+    "Source mix: discovery\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, contact, lightning.",
+    "Representative service summary: 110+ developer tools accessible via L402 micropayments. Code review, bug finder, SQL optimizer, unit test generator, Dockerfile generator, CI/CD pipeline, data cleaning, API docs, security scanning, legal drafts, and more. POST with {\"task\"\u2026",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/the-ark.ts
+++ b/src/registry/providers/the-ark.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'the-ark',
+  name: "The Ark",
+  websiteUrl: "https://arknode.ai",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "The Ark appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'the-ark-ai',
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: ai; average reliability 28.3.",
+    "Representative candidate endpoint: https://arknode.ai/task",
+    "Main website candidate: https://arknode.ai (title: The Ark AI \u2014 Chat with AI, Pay with Lightning \u26a1)",
+    "Source mix: satring\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, contact, lightning.",
+    "Representative service summary: 120+ AI services paid with Bitcoin Lightning. Code gen, image generation, voice synthesis, research, translation, legal drafting, medical summaries, SEO analysis, content writing, DevOps automation, data analysis \u2014 all pay-per-task via L402\u2026",
+    "Mapped as duplicate of provider key 'the-ark-ai'.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/thenode-it-com.ts
+++ b/src/registry/providers/thenode-it-com.ts
@@ -1,0 +1,28 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'thenode-it-com',
+  name: "thenode.it.com",
+  websiteUrl: "https://thenode.it.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'duplicate',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "thenode.it.com appears to be an alias or duplicate listing for an already-tracked provider and was added to avoid re-review.",
+  duplicateOf: 'the-ark-ai',
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: tools; average reliability 10.0.",
+    "Representative candidate endpoint: https://thenode.it.com/services",
+    "Main website candidate: https://thenode.it.com (title: The Ark AI \u2014 Chat with AI, Pay with Lightning \u26a1)",
+    "Source mix: satring\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: terms, contact, lightning.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Mapped as duplicate of provider key 'the-ark-ai'.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/twit-sh.ts
+++ b/src/registry/providers/twit-sh.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'twit-sh',
+  name: "twit.sh",
+  websiteUrl: "https://twit.sh",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "twit.sh looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'x402.twit.sh/articles/by/id'.",
+  endpointCandidates: ["id", "members"],
+  notes: [
+    "402index snapshot on 2026-04-20: 21 indexed L402 services; top categories: ai; average reliability 100.0.",
+    "Representative candidate endpoint: https://x402.twit.sh/articles/by/id",
+    "Main website candidate: https://twit.sh (title: twit.sh \u2014 Plug AI agents into X)",
+    "Source mix: satring\u00d721.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/unhuman-moneydevkit.ts
+++ b/src/registry/providers/unhuman-moneydevkit.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'unhuman-moneydevkit',
+  name: "Unhuman (moneydevkit)",
+  websiteUrl: "https://unhuman.coffee",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "Unhuman (moneydevkit) looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'Unhuman Domains \u2014 AI Domain Registration'.",
+  endpointCandidates: ["register", "order", "generate"],
+  notes: [
+    "402index snapshot on 2026-04-20: 3 indexed L402 services; top categories: payments, media, tools; average reliability 79.3.",
+    "Representative candidate endpoint: https://unhuman.domains/api/domains/example.dev/register",
+    "Main website candidate: https://unhuman.coffee (title: Unhuman Coffee)",
+    "Source mix: self-registered\u00d73.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, l402, lightning.",
+    "Representative service summary: Domain registrar built for AI agents. Search, register, and manage domains via API. Pay with Bitcoin Lightning. Supports com, net, org, io, dev, app, xyz, co, ai TLDs.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/unhuman-store.ts
+++ b/src/registry/providers/unhuman-store.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'unhuman-store',
+  name: "unhuman.store",
+  websiteUrl: "https://unhuman.shopping",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "unhuman.store looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'unhuman shopping'.",
+  endpointCandidates: ["order"],
+  notes: [
+    "402index snapshot on 2026-04-20: 1 indexed L402 services; top categories: commerce; average reliability 74.3.",
+    "Representative candidate endpoint: https://unhuman.shopping/api/order",
+    "Main website candidate: https://unhuman.shopping (title: unhuman shopping)",
+    "Source mix: self-registered\u00d71.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: pricing, contact, l402, lightning.",
+    "Representative service summary: Buy products from Amazon via API, paid with Bitcoin Lightning. Search the catalog for free, then place orders with L402 payment. Supports order tracking, cancellation, and gift orders.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/wot-scoring-api.ts
+++ b/src/registry/providers/wot-scoring-api.ts
@@ -1,0 +1,25 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'wot-scoring-api',
+  name: "WoT Scoring API",
+  websiteUrl: "https://wot.klabo.world",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'rejected',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "WoT Scoring API is not a good landing-page candidate right now because the provider identity or host quality still looks too weak.",
+  notes: [
+    "402index snapshot on 2026-04-20: 50 indexed L402 services; top categories: identity, real-time-data, uncategorized; average reliability 35.0.",
+    "Representative candidate endpoint: https://wot.klabo.world/score?pubkey=test",
+    "Main website candidate: https://wot.klabo.world.",
+    "Source mix: satring\u00d746, l402apps\u00d74.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Returns normalized PageRank trust score (0-100), composite score from external NIP-85 providers, follower count, engagement metrics, topics, active hours, and reports. Accepts hex pubkeys or NIP-19 npub format.",
+    "Current rejection is based on weak provider/host credibility, not on 402index health alone.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/x402engine.ts
+++ b/src/registry/providers/x402engine.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'x402engine',
+  name: "x402engine",
+  websiteUrl: "https://x402-gateway-production.up.railway.app",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "x402engine looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'x402-gateway-production.up.railway.app/api/crypto/price'.",
+  endpointCandidates: ["price"],
+  notes: [
+    "402index snapshot on 2026-04-20: 2 indexed L402 services; top categories: ai; average reliability 94.7.",
+    "Representative candidate endpoint: https://x402-gateway-production.up.railway.app/api/crypto/price",
+    "Main website candidate: https://x402-gateway-production.up.railway.app (title: x402engine \u2014 Pay-per-call APIs for AI Agents)",
+    "Source mix: satring\u00d72.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Observed website/discovery signals: docs, pricing, mcp.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/providers/x402scan.ts
+++ b/src/registry/providers/x402scan.ts
@@ -1,0 +1,26 @@
+import type { ProviderRegistryEntry } from '../types';
+
+const provider = {
+  key: 'x402scan',
+  name: "x402scan",
+  websiteUrl: "https://x402scan.com",
+  protocols: ['L402'],
+  discoverySources: ['402index.io'],
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  lastCheckedAt: '2026-04-20',
+  summary: "x402scan looks credible enough for trial intake based on website, discovery, and service usefulness signals; the most promising first landing-page candidate is 'www.x402scan.com/api/x402/facilitators'.",
+  endpointCandidates: ["facilitators", "stats", "merchants"],
+  notes: [
+    "402index snapshot on 2026-04-20: 6 indexed L402 services; top categories: real-time-data; average reliability 100.0.",
+    "Representative candidate endpoint: https://www.x402scan.com/api/x402/facilitators",
+    "Main website candidate: https://x402scan.com (title: x402scan | x402 Ecosystem Explorer)",
+    "Source mix: satring\u00d76.",
+    "402index health was recorded as telemetry only and was not used as the approval gate for this intake pass.",
+    "Representative service summary: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ProviderRegistryEntry;
+
+export default provider;

--- a/src/registry/services/402index-402index-services-api.ts
+++ b/src/registry/services/402index-402index-services-api.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: '402index-402index-services-api',
+  providerKey: '402index',
+  name: "402index Services API",
+  endpointUrl: "https://402index.io/api/v1/services?l402=require",
+  category: "Tools / Directory",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative 402index endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider '402index'.",
+    "Endpoint URL: https://402index.io/api/v1/services?l402=require",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: JSON API for querying indexed L402 and x402 paid API endpoints. Supports filtering by protocol, category, health status, and text search. Free tier with L402 upgrade for higher rate limits.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/a-little-bit-of-money-a-little-bit-of-money.ts
+++ b/src/registry/services/a-little-bit-of-money-a-little-bit-of-money.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'a-little-bit-of-money-a-little-bit-of-money',
+  providerKey: 'a-little-bit-of-money',
+  name: "A little bit of money",
+  endpointUrl: "https://alittlebitofmoney.com/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative A-LITTLE-BIT-OF-MONEY endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'A-LITTLE-BIT-OF-MONEY'.",
+    "Endpoint URL: https://alittlebitofmoney.com/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Lightning-paid proxy to AI APIs. Chat completions, image generation, embeddings, audio, video. No account, no API key \u2014 pay per request in sats.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/alex-chen-autopilotai-skillscan-ai-agent-security-scanner.ts
+++ b/src/registry/services/alex-chen-autopilotai-skillscan-ai-agent-security-scanner.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'alex-chen-autopilotai-skillscan-ai-agent-security-scanner',
+  providerKey: 'alex-chen-autopilotai',
+  name: "SkillScan - AI Agent Security Scanner",
+  endpointUrl: "https://skillscan.chitacloud.dev/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Alex Chen (AutoPilotAI) endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Alex Chen (AutoPilotAI)'.",
+    "Endpoint URL: https://skillscan.chitacloud.dev/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Security scanner for AI agent skills and MCP tools. CRITICAL BUG FIXED March 4: now correctly fetches SKILL.md from ClawHub API instead of HTML pages - all scans now accurate. Scans for prompt injection, capability overreach, supply chain r\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/aperezvigoa-satsapi.ts
+++ b/src/registry/services/aperezvigoa-satsapi.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'aperezvigoa-satsapi',
+  providerKey: 'aperezvigoa',
+  name: "SatsAPI",
+  endpointUrl: "https://satsapi.dev/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Aperezvigoa endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Aperezvigoa'.",
+    "Endpoint URL: https://satsapi.dev/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Bitcoin market intelligence API with L402 pay-per-call auth. \r\n8 endpoints: price/RSI/MACD, mempool fees, on-chain metrics, \r\nderivatives, AI news sentiment, 9-factor BUY/SELL/HOLD signal \r\nand full market summary. Designed for developers a\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/asterpay-x402-asterpay-io-v1-agent-discovery.ts
+++ b/src/registry/services/asterpay-x402-asterpay-io-v1-agent-discovery.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'asterpay-x402-asterpay-io-v1-agent-discovery',
+  providerKey: 'asterpay',
+  name: "x402.asterpay.io/v1/agent/discovery",
+  endpointUrl: "https://x402.asterpay.io/v1/agent/discovery",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative AsterPay endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'AsterPay'.",
+    "Endpoint URL: https://x402.asterpay.io/v1/agent/discovery",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/bitcoin-benji-bitcoin-benji-api-mempool-intelligence-ai-utilities.ts
+++ b/src/registry/services/bitcoin-benji-bitcoin-benji-api-mempool-intelligence-ai-utilities.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'bitcoin-benji-bitcoin-benji-api-mempool-intelligence-ai-utilities',
+  providerKey: 'bitcoin-benji',
+  name: "Bitcoin Benji API \u2014 Mempool Intelligence + AI Utilities",
+  endpointUrl: "https://ovz5i27at6cjnfz2mhenkhsxqgwjh4rpkyju5ctr6xgju2hdklsfbpqd.onion/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Bitcoin Benji endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Bitcoin Benji'.",
+    "Endpoint URL: https://ovz5i27at6cjnfz2mhenkhsxqgwjh4rpkyju5ctr6xgju2hdklsfbpqd.onion/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: 16 paid L402 endpoints: Bitcoin mempool intelligence (fee estimates, whale alerts, mempool state, block data) + 11 AI utility APIs (summarize, sentiment, translate, grammar, code-review, extract, scrape, agent, classify, rewrite, explain). \u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/boltwork-boltwork-web-page-summariser.ts
+++ b/src/registry/services/boltwork-boltwork-web-page-summariser.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'boltwork-boltwork-web-page-summariser',
+  providerKey: 'boltwork',
+  name: "Boltwork Web Page Summariser",
+  endpointUrl: "https://parsebit-lnd.fly.dev/extract/webpage",
+  category: "Ai / Text",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Boltwork endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Boltwork'.",
+    "Endpoint URL: https://parsebit-lnd.fly.dev/extract/webpage",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Submit any web page URL and receive a structured AI summary including title, key points, topics, and sentiment. Powered by Claude. Pay 100 sats per request via Bitcoin Lightning L402.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/cabal-cabal-getcabal-com-api.ts
+++ b/src/registry/services/cabal-cabal-getcabal-com-api.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'cabal-cabal-getcabal-com-api',
+  providerKey: 'cabal',
+  name: "Cabal: getcabal.com API",
+  endpointUrl: "https://getcabal.com/api/agent_api/v1/connectors",
+  category: "Uncategorized",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Cabal endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Cabal'.",
+    "Endpoint URL: https://getcabal.com/api/agent_api/v1/connectors",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Get list of advisors and connectors in your network who can make introductions",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/catalunyalnd-fortune-cookie.ts
+++ b/src/registry/services/catalunyalnd-fortune-cookie.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'catalunyalnd-fortune-cookie',
+  providerKey: 'catalunyalnd',
+  name: "Fortune Cookie \u26a1\ud83e\udd60",
+  endpointUrl: "https://l402-fortune-cookie.yf-ae7.workers.dev/api/fortune",
+  category: "Tools",
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative CatalunyaLND endpoint tracked in the service registry, but this provider is still lower priority for activation.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'CatalunyaLND'.",
+    "Endpoint URL: https://l402-fortune-cookie.yf-ae7.workers.dev/api/fortune",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Get a random fortune cookie wisdom for 1 sat. Minimal L402 demo API powered by Cloudflare Workers + LNbits.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/claudio-ai-agent-bitcoin-data-oracle.ts
+++ b/src/registry/services/claudio-ai-agent-bitcoin-data-oracle.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'claudio-ai-agent-bitcoin-data-oracle',
+  providerKey: 'claudio-ai-agent',
+  name: "Bitcoin Data Oracle",
+  endpointUrl: "https://oracle.neofreight.net/",
+  category: "Real Time Data",
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Claudio (AI Agent) endpoint tracked in the service registry, but this provider is still lower priority for activation.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Claudio (AI Agent)'.",
+    "Endpoint URL: https://oracle.neofreight.net/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Verify Bitcoin transactions, addresses, and invoices. Get fee estimates, block height, and BTC/USD price with Nostr-signed attestation. Real mainnet node. 21 sats/request via L402.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/djd-agent-score-djdagentscore-dev-v1-certification-apply.ts
+++ b/src/registry/services/djd-agent-score-djdagentscore-dev-v1-certification-apply.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'djd-agent-score-djdagentscore-dev-v1-certification-apply',
+  providerKey: 'djd-agent-score',
+  name: "djdagentscore.dev/v1/certification/apply",
+  endpointUrl: "https://djdagentscore.dev/v1/certification/apply",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative DJD Agent Score endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'DJD Agent Score'.",
+    "Endpoint URL: https://djdagentscore.dev/v1/certification/apply",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/einstein-ai-emc2ai-io-x402-bitquery-arbitragescanner.ts
+++ b/src/registry/services/einstein-ai-emc2ai-io-x402-bitquery-arbitragescanner.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'einstein-ai-emc2ai-io-x402-bitquery-arbitragescanner',
+  providerKey: 'einstein-ai',
+  name: "emc2ai.io/x402/bitquery/arbitragescanner",
+  endpointUrl: "https://emc2ai.io/x402/bitquery/arbitragescanner",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Einstein AI endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Einstein AI'.",
+    "Endpoint URL: https://emc2ai.io/x402/bitquery/arbitragescanner",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/fewsats-fewsats.ts
+++ b/src/registry/services/fewsats-fewsats.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'fewsats-fewsats',
+  providerKey: 'fewsats',
+  name: "Fewsats",
+  endpointUrl: "https://fewsats.com/",
+  category: "Crypto / Payments",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Fewsats endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Fewsats'.",
+    "Endpoint URL: https://fewsats.com/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Payment infrastructure for AI agents. Enables autonomous agents to pay and get paid using L402.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/ganamos-ganamos-create-job.ts
+++ b/src/registry/services/ganamos-ganamos-create-job.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'ganamos-ganamos-create-job',
+  providerKey: 'ganamos',
+  name: "Ganamos: Create Job",
+  endpointUrl: "https://www.ganamos.earth/api/posts",
+  category: "Tools / Marketplace",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Ganamos endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Ganamos'.",
+    "Endpoint URL: https://www.ganamos.earth/api/posts",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Post a Bitcoin-funded bounty job. Costs reward amount + 10 sat API fee via L402 Lightning payment. Returns post_id and status URL.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/hyperdope-lightning-fee-oracle.ts
+++ b/src/registry/services/hyperdope-lightning-fee-oracle.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'hyperdope-lightning-fee-oracle',
+  providerKey: 'hyperdope',
+  name: "Lightning Fee Oracle",
+  endpointUrl: "https://l402.services/ln/fees",
+  category: "Data",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Hyperdope endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Hyperdope'.",
+    "Endpoint URL: https://l402.services/ln/fees",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Fee oracle \u2014 network-wide fee distribution percentiles, daily fee change trends, volatility metrics. Optional ?pubkey= for per-node detail, ?days= for window",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/l402-apps-l402-apps-lightning-lottery.ts
+++ b/src/registry/services/l402-apps-l402-apps-lightning-lottery.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'l402-apps-l402-apps-lightning-lottery',
+  providerKey: 'l402-apps',
+  name: "L402 Apps: Lightning Lottery",
+  endpointUrl: "https://www.l402apps.com/api/lottery/enter",
+  category: "Bitcoin",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative L402 Apps endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'L402 Apps'.",
+    "Endpoint URL: https://www.l402apps.com/api/lottery/enter",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Enter the 24h Lightning Lottery. More sats = higher winning probability. Provide a Lightning Address or node pubkey for payout.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/lightning-enable-agent-commerce-store.ts
+++ b/src/registry/services/lightning-enable-agent-commerce-store.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'lightning-enable-agent-commerce-store',
+  providerKey: 'lightning-enable',
+  name: "Agent Commerce Store",
+  endpointUrl: "https://agent-commerce.store/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Lightning Enable endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Lightning Enable'.",
+    "Endpoint URL: https://agent-commerce.store/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: 13 L402-gated API endpoints for AI agents. SEC filings, PubMed, weather, census, FRED economics, currency exchange, Wikipedia, arXiv, OpenAlex, OpenFDA. 1-10 sats per call. No API keys. Payment is authentication.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/lightning-faucet-lightning-faucet-profanity-filter.ts
+++ b/src/registry/services/lightning-faucet-lightning-faucet-profanity-filter.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'lightning-faucet-lightning-faucet-profanity-filter',
+  providerKey: 'lightning-faucet',
+  name: "Lightning Faucet: Profanity Filter",
+  endpointUrl: "https://lightningfaucet.com/api/l402/profanity_filter",
+  category: "Tools",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Lightning Faucet endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Lightning Faucet'.",
+    "Endpoint URL: https://lightningfaucet.com/api/l402/profanity_filter",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Content moderation API. Detect and filter profanity in text. Returns flagged words and clean version. 10 sats per request.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/lpx-digital-group-isitarug.ts
+++ b/src/registry/services/lpx-digital-group-isitarug.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'lpx-digital-group-isitarug',
+  providerKey: 'lpx-digital-group',
+  name: "IsItARug",
+  endpointUrl: "https://isitarug.com/",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative LPX Digital Group endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'LPX Digital Group'.",
+    "Endpoint URL: https://isitarug.com/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Solana token safety scanner. Paste any token address, get an instant AI-powered rug pull risk analysis. Pay 10 sats per scan via Lightning. No signup required.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/lpx-digital-group-llc-lightningprox-multi-model-ai-gateway.ts
+++ b/src/registry/services/lpx-digital-group-llc-lightningprox-multi-model-ai-gateway.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'lpx-digital-group-llc-lightningprox-multi-model-ai-gateway',
+  providerKey: 'lpx-digital-group-llc',
+  name: "LightningProx \u2014 Multi-Model AI Gateway",
+  endpointUrl: "https://lightningprox.com/v1/messages",
+  category: "Ai / Llm",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative LPX Digital Group LLC endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'LPX Digital Group LLC'.",
+    "Endpoint URL: https://lightningprox.com/v1/messages",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Pay-per-request AI inference via Bitcoin Lightning L402. 19+ models: Anthropic Claude, OpenAI GPT-4, and open models including Llama 4, DeepSeek V3, Mistral, Gemini. No accounts, no API keys. Drop-in OpenAI SDK replacement. Inline L402 chal\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/maximumsats-ai-dvm.ts
+++ b/src/registry/services/maximumsats-ai-dvm.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'maximumsats-ai-dvm',
+  providerKey: 'maximumsats',
+  name: "AI DVM",
+  endpointUrl: "https://maximumsats.com/api/dvm",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative MaximumSats endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'MaximumSats'.",
+    "Endpoint URL: https://maximumsats.com/api/dvm",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: General-purpose AI assistant via DVM (Data Vending Machine). Free tier: 1 query/24h, then L402. Also supports x402 (USDC).",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/minifetch-minifetch-com-api-v1-x402-extract-url-content.ts
+++ b/src/registry/services/minifetch-minifetch-com-api-v1-x402-extract-url-content.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'minifetch-minifetch-com-api-v1-x402-extract-url-content',
+  providerKey: 'minifetch',
+  name: "minifetch.com/api/v1/x402/extract/url-content",
+  endpointUrl: "https://minifetch.com/api/v1/x402/extract/url-content",
+  category: "Real Time Data",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Minifetch endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Minifetch'.",
+    "Endpoint URL: https://minifetch.com/api/v1/x402/extract/url-content",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/moltalyzer-api-moltalyzer-xyz-api-github-digests.ts
+++ b/src/registry/services/moltalyzer-api-moltalyzer-xyz-api-github-digests.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'moltalyzer-api-moltalyzer-xyz-api-github-digests',
+  providerKey: 'moltalyzer',
+  name: "api.moltalyzer.xyz/api/github/digests",
+  endpointUrl: "https://api.moltalyzer.xyz/api/github/digests",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Moltalyzer endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Moltalyzer'.",
+    "Endpoint URL: https://api.moltalyzer.xyz/api/github/digests",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/mutinywallet-mutinynet-faucet.ts
+++ b/src/registry/services/mutinywallet-mutinynet-faucet.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'mutinywallet-mutinynet-faucet',
+  providerKey: 'mutinywallet',
+  name: "Mutinynet Faucet",
+  endpointUrl: "https://faucet.mutinynet.com/api/l402",
+  category: "Bitcoin",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative MutinyWallet endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'MutinyWallet'.",
+    "Endpoint URL: https://faucet.mutinynet.com/api/l402",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Lightning-gated faucet on Bitcoin's Mutinynet testnet. Pay a small L402 invoice to receive testnet sats.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/mycelia-signal-mycelia-signal-dlc-threshold-oracle.ts
+++ b/src/registry/services/mycelia-signal-mycelia-signal-dlc-threshold-oracle.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'mycelia-signal-mycelia-signal-dlc-threshold-oracle',
+  providerKey: 'mycelia-signal',
+  name: "Mycelia Signal DLC Threshold Oracle",
+  endpointUrl: "https://api.myceliasignal.com/dlc/oracle/threshold",
+  category: "Uncategorized",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Mycelia Signal endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Mycelia Signal'.",
+    "Endpoint URL: https://api.myceliasignal.com/dlc/oracle/threshold",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Register a DLC threshold contract (pair, strike, direction ABOVE/BELOW, expiry Unix timestamp). Schnorr attestation over secp256k1 for Bitcoin smart contract settlement. Free testnet available at /dlc/oracle/threshold/preview.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/open-agents-open-agents.ts
+++ b/src/registry/services/open-agents-open-agents.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'open-agents-open-agents',
+  providerKey: 'open-agents',
+  name: "Open Agents",
+  endpointUrl: "https://openagents.com/",
+  category: "Tools",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Open Agents endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Open Agents'.",
+    "Endpoint URL: https://openagents.com/",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: An open platform for AI agents, built in public from scratch.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/paul-certvera-update-notifications.ts
+++ b/src/registry/services/paul-certvera-update-notifications.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'paul-certvera-update-notifications',
+  providerKey: 'paul',
+  name: "CertVera Update Notifications",
+  endpointUrl: "https://certvera.com/api/l402?action=l402_timestamp_update",
+  category: "Identity",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Paul endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Paul'.",
+    "Endpoint URL: https://certvera.com/api/l402?action=l402_timestamp_update",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Update webhook and email notification settings on an existing Bitcoin timestamp. POST {action: l402_timestamp_update, timestamp_id: <id>, webhook_url: <url>, notification_email: <email>} to certvera.com/api/l402. 10 sats via L402. Modify no\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/plebtv-plebtv-integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee.ts
+++ b/src/registry/services/plebtv-plebtv-integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'plebtv-plebtv-integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee',
+  providerKey: 'plebtv',
+  name: "PlebTV: Integrating Bitcoin Payments with the Zaprite API | Live Coding Workshop with NickTee",
+  endpointUrl: "https://www.plebtv.com/api/l402/video/integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee-jyd0ko",
+  category: "Technology",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative PlebTV endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'PlebTV'.",
+    "Endpoint URL: https://www.plebtv.com/api/l402/video/integrating-bitcoin-payments-with-the-zaprite-api-live-coding-workshop-with-nicktee-jyd0ko",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: NickTee dives into the Zaprite API your gateway to Bitcoin-native invoicing, payment processing, and financial automation. Whether you're building client apps, hacking on side projects, or just exploring how to integrate Lightning and on-ch\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/prime-technology-u-s-grid-cheapest-electricity-zones.ts
+++ b/src/registry/services/prime-technology-u-s-grid-cheapest-electricity-zones.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'prime-technology-u-s-grid-cheapest-electricity-zones',
+  providerKey: 'prime-technology',
+  name: "U.S. Grid \u2014 Cheapest Electricity Zones",
+  endpointUrl: "https://grid.ptsolutions.io/v1/cheapest",
+  category: "Real Time Data",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Prime Technology endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Prime Technology'.",
+    "Endpoint URL: https://grid.ptsolutions.io/v1/cheapest",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Top N cheapest electricity pricing zones right now across all 8 U.S. ISOs: ERCOT, CAISO, MISO, NYISO, ISONE, SPP, WEIM, SPP_WEIS. Ranked by current LMP. Pass ?limit=N to control result count. Ideal for Bitcoin miners and data center operato\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/proxy402-proxy402-chat-completions-348-models.ts
+++ b/src/registry/services/proxy402-proxy402-chat-completions-348-models.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'proxy402-proxy402-chat-completions-348-models',
+  providerKey: 'proxy402',
+  name: "proxy402: Chat Completions (348 models)",
+  endpointUrl: "https://api.proxy402.fun/v1/chat/completions",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative proxy402 endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'proxy402'.",
+    "Endpoint URL: https://api.proxy402.fun/v1/chat/completions",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: OpenAI-compatible chat completions API proxying 348+ models via OpenRouter. Pay-per-request with Lightning. Supports GPT, Claude, Mistral, Grok, Gemini, and more. No account required.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/rob-agent-web-search.ts
+++ b/src/registry/services/rob-agent-web-search.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'rob-agent-web-search',
+  providerKey: 'rob',
+  name: "agent web search",
+  endpointUrl: "https://botlab.dev/api/web-search",
+  category: "Ai / Ml",
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative rob endpoint tracked in the service registry, but this provider is still lower priority for activation.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'rob'.",
+    "Endpoint URL: https://botlab.dev/api/web-search",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: AI-powered web search. Returns a synthesized, cited answer from Brave Search results using Gemini 3 Flash \u2014 not just links. Supports GET and POST, responds with structured JSON. No API keys or accounts needed.\nTiers: [100 sats: 2,500 tokens\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/robtex-x402-robtex-com-api-v1-as-info.ts
+++ b/src/registry/services/robtex-x402-robtex-com-api-v1-as-info.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'robtex-x402-robtex-com-api-v1-as-info',
+  providerKey: 'robtex',
+  name: "x402.robtex.com/api/v1/as_info",
+  endpointUrl: "https://x402.robtex.com/api/v1/as_info",
+  category: "Tools",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Robtex endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Robtex'.",
+    "Endpoint URL: https://x402.robtex.com/api/v1/as_info",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/satoshi-dispatches-mystere-me-satoshi-dispatches-dispatch-series.ts
+++ b/src/registry/services/satoshi-dispatches-mystere-me-satoshi-dispatches-dispatch-series.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'satoshi-dispatches-mystere-me-satoshi-dispatches-dispatch-series',
+  providerKey: 'satoshi-dispatches-mystere-me',
+  name: "Satoshi Dispatches \u2014 Dispatch Series",
+  endpointUrl: "https://dispatches.mystere.me/dispatch/002",
+  category: "Ai / Content",
+  reviewStatus: 'deferred',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Satoshi (dispatches.mystere.me) endpoint tracked in the service registry, but this provider is still lower priority for activation.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Satoshi (dispatches.mystere.me)'.",
+    "Endpoint URL: https://dispatches.mystere.me/dispatch/002",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: 45 dispatches from an autonomous AI agent running a mainnet Lightning node on a Raspberry Pi. Pay per dispatch, 10 sats. #001 free. Ask Satoshi at /ask \u2014 100 sats/question, agent-answered. lnget-compatible. L402 macaroon + BOLT11 invoice on\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/satring-satring-directory-api.ts
+++ b/src/registry/services/satring-satring-directory-api.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'satring-satring-directory-api',
+  providerKey: 'satring',
+  name: "Satring Directory API",
+  endpointUrl: "https://satring.com/api/v1/services",
+  category: "Tools / Search",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative satring endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Satring'.",
+    "Endpoint URL: https://satring.com/api/v1/services",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: L402 + x402 paid API directory. GET for paginated listing with category/protocol filters, detail by slug, and search. POST to submit new services (1000 sats / $0.50 USDC). PATCH to edit with token.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/satsback-com-satsback-agent-api.ts
+++ b/src/registry/services/satsback-com-satsback-agent-api.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'satsback-com-satsback-agent-api',
+  providerKey: 'satsback-com',
+  name: "Satsback Agent API",
+  endpointUrl: "https://satsback.com/api/v2/l402/register",
+  category: "Earn / Cashback",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Satsback.com endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Satsback.com'.",
+    "Endpoint URL: https://satsback.com/api/v2/l402/register",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Cashback infrastructure for AI agents, settled in sats. Browse 10,000+ online retailers, generate affiliate-tracked links, and route Bitcoin payouts directly to Lightning addresses. L402-gated API with full MCP server support \u2014 built for ag\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/satwork-satwork-earn-sats-optimization-bounties-for-ai-agents.ts
+++ b/src/registry/services/satwork-satwork-earn-sats-optimization-bounties-for-ai-agents.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'satwork-satwork-earn-sats-optimization-bounties-for-ai-agents',
+  providerKey: 'satwork',
+  name: "satwork: Earn sats \u2014 optimization bounties for AI agents",
+  endpointUrl: "https://satwork.ai/api/l402/targets",
+  category: "Earn / Optimization",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative satwork endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'satwork'.",
+    "Endpoint URL: https://satwork.ai/api/l402/targets",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: The first earn service on 402index. AI agents arrive with zero sats and start earning immediately \u2014 no account, no API key, no signup. Propose parameter optimizations (2 sats/attempt), get scored deterministically in a sandbox, earn 50-500 \u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/semagram-io-semagram-io-semantic-search-api-for-telegram-search-across-1m-channels-150k-chats-and-100k-bots-using-hybrid.ts
+++ b/src/registry/services/semagram-io-semagram-io-semantic-search-api-for-telegram-search-across-1m-channels-150k-chats-and-100k-bots-using-hybrid.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'semagram-io-semagram-io-semantic-search-api-for-telegram-search-across-1m-channels-150k-chats-and-100k-bots-using-hybrid',
+  providerKey: 'semagram-io',
+  name: "semagram.io: Semantic search API for Telegram. Search across 1M channels, 150K chats, and 100K bots using hybrid search (embedding similarity + BM25 keyword matches).",
+  endpointUrl: "https://semagram.io/api/agent/search",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative semagram.io endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'semagram.io'.",
+    "Endpoint URL: https://semagram.io/api/agent/search",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Semantic search API for Telegram. Search across 1M channels, 150K chats, and 100K bots using hybrid search (embedding similarity + BM25 keyword matches).",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/sociologic-rng-sociologic-ai-random.ts
+++ b/src/registry/services/sociologic-rng-sociologic-ai-random.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'sociologic-rng-sociologic-ai-random',
+  providerKey: 'sociologic',
+  name: "rng.sociologic.ai/random",
+  endpointUrl: "https://rng.sociologic.ai/random",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative SocioLogic endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'SocioLogic'.",
+    "Endpoint URL: https://rng.sociologic.ai/random",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/spark-mempool-fee-estimates.ts
+++ b/src/registry/services/spark-mempool-fee-estimates.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'spark-mempool-fee-estimates',
+  providerKey: 'spark',
+  name: "Mempool Fee Estimates",
+  endpointUrl: "https://l402.lndyn.com/api/mempool-fees",
+  category: "Bitcoin",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Spark endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Spark'.",
+    "Endpoint URL: https://l402.lndyn.com/api/mempool-fees",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Real-time Bitcoin mempool fee estimates (sat/vB) for next block, ~10min, ~30min targets",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/stabletravel-dev-stabletravel-dev-api-reference-airline-routes.ts
+++ b/src/registry/services/stabletravel-dev-stabletravel-dev-api-reference-airline-routes.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'stabletravel-dev-stabletravel-dev-api-reference-airline-routes',
+  providerKey: 'stabletravel-dev',
+  name: "stabletravel.dev/api/reference/airline-routes",
+  endpointUrl: "https://stabletravel.dev/api/reference/airline-routes",
+  category: "Tools",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative stabletravel.dev endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'stabletravel.dev'.",
+    "Endpoint URL: https://stabletravel.dev/api/reference/airline-routes",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/stableupload-stableupload-dev-api-site.ts
+++ b/src/registry/services/stableupload-stableupload-dev-api-site.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'stableupload-stableupload-dev-api-site',
+  providerKey: 'stableupload',
+  name: "stableupload.dev/api/site",
+  endpointUrl: "https://stableupload.dev/api/site",
+  category: "Storage",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative StableUpload endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'StableUpload'.",
+    "Endpoint URL: https://stableupload.dev/api/site",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/taskhawk-systems-kevros-governance-verify.ts
+++ b/src/registry/services/taskhawk-systems-kevros-governance-verify.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'taskhawk-systems-kevros-governance-verify',
+  providerKey: 'taskhawk-systems',
+  name: "Kevros Governance Verify",
+  endpointUrl: "https://governance.taskhawktech.com/governance/verify",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative TaskHawk Systems endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'TaskHawk Systems'.",
+    "Endpoint URL: https://governance.taskhawktech.com/governance/verify",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Runtime intelligence action verification with signed ALLOW/CLAMP/DENY decision",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/the-ark-ai-the-ark-ai-multi-tool-l402-gateway.ts
+++ b/src/registry/services/the-ark-ai-the-ark-ai-multi-tool-l402-gateway.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'the-ark-ai-the-ark-ai-multi-tool-l402-gateway',
+  providerKey: 'the-ark-ai',
+  name: "The Ark AI: Multi-Tool L402 Gateway",
+  endpointUrl: "https://arknode.ai/l402/task",
+  category: "Ai",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative The Ark AI endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'The Ark AI'.",
+    "Endpoint URL: https://arknode.ai/l402/task",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: 110+ developer tools accessible via L402 micropayments. Code review, bug finder, SQL optimizer, unit test generator, Dockerfile generator, CI/CD pipeline, data cleaning, API docs, security scanning, legal drafts, and more. POST with {\"task\"\u2026",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/twit-sh-x402-twit-sh-articles-by-id.ts
+++ b/src/registry/services/twit-sh-x402-twit-sh-articles-by-id.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'twit-sh-x402-twit-sh-articles-by-id',
+  providerKey: 'twit-sh',
+  name: "x402.twit.sh/articles/by/id",
+  endpointUrl: "https://x402.twit.sh/articles/by/id",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative twit.sh endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'twit.sh'.",
+    "Endpoint URL: https://x402.twit.sh/articles/by/id",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/unhuman-moneydevkit-unhuman-domains-ai-domain-registration.ts
+++ b/src/registry/services/unhuman-moneydevkit-unhuman-domains-ai-domain-registration.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'unhuman-moneydevkit-unhuman-domains-ai-domain-registration',
+  providerKey: 'unhuman-moneydevkit',
+  name: "Unhuman Domains \u2014 AI Domain Registration",
+  endpointUrl: "https://unhuman.domains/api/domains/example.dev/register",
+  category: "Tools",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative Unhuman (moneydevkit) endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'Unhuman (moneydevkit)'.",
+    "Endpoint URL: https://unhuman.domains/api/domains/example.dev/register",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Domain registrar built for AI agents. Search, register, and manage domains via API. Pay with Bitcoin Lightning. Supports com, net, org, io, dev, app, xyz, co, ai TLDs.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/unhuman-store-unhuman-shopping.ts
+++ b/src/registry/services/unhuman-store-unhuman-shopping.ts
@@ -1,0 +1,24 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'unhuman-store-unhuman-shopping',
+  providerKey: 'unhuman-store',
+  name: "unhuman shopping",
+  endpointUrl: "https://unhuman.shopping/api/order",
+  category: "Commerce / Shopping",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative unhuman.store endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'unhuman.store'.",
+    "Endpoint URL: https://unhuman.shopping/api/order",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Buy products from Amazon via API, paid with Bitcoin Lightning. Search the catalog for free, then place orders with L402 payment. Supports order tracking, cancellation, and gift orders.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/x402engine-x402-gateway-production-up-railway-app-api-crypto-price.ts
+++ b/src/registry/services/x402engine-x402-gateway-production-up-railway-app-api-crypto-price.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'x402engine-x402-gateway-production-up-railway-app-api-crypto-price',
+  providerKey: 'x402engine',
+  name: "x402-gateway-production.up.railway.app/api/crypto/price",
+  endpointUrl: "https://x402-gateway-production.up.railway.app/api/crypto/price",
+  category: "Ai / Ml",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative x402engine endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'x402engine'.",
+    "Endpoint URL: https://x402-gateway-production.up.railway.app/api/crypto/price",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;

--- a/src/registry/services/x402scan-www-x402scan-com-api-x402-facilitators.ts
+++ b/src/registry/services/x402scan-www-x402scan-com-api-x402-facilitators.ts
@@ -1,0 +1,25 @@
+import type { ServiceRegistryEntry } from '../types';
+
+const service = {
+  key: 'x402scan-www-x402scan-com-api-x402-facilitators',
+  providerKey: 'x402scan',
+  name: "www.x402scan.com/api/x402/facilitators",
+  endpointUrl: "https://www.x402scan.com/api/x402/facilitators",
+  category: "Real Time Data",
+  reviewStatus: 'approved-for-trial',
+  reviewSource: 'manual-intake',
+  activationStatus: 'not-started',
+  landingPageStatus: 'coming-soon',
+  lastCheckedAt: '2026-04-20',
+  summary: "Representative x402scan endpoint added from 402index for service-level review before any landing page is published.",
+  notes: [
+    "Discovered via 402index on 2026-04-20 and selected as the most promising representative endpoint for provider 'x402scan'.",
+    "Endpoint URL: https://www.x402scan.com/api/x402/facilitators",
+    "No direct schema check or paid activation test has been recorded yet.",
+    "402index health was treated as informational only during this intake pass.",
+    "Directory description: Added by scraper. Domain owners can authenticate for free to edit information.",
+    "Representative endpoint details still rely on low-confidence scraper metadata and need direct validation before activation.",
+  ],
+} satisfies ServiceRegistryEntry;
+
+export default service;


### PR DESCRIPTION
## Summary
- add 63 new provider registry entries discovered from the 402index L402 API
- add 48 representative service registry entries for approved-for-trial and deferred providers
- treat 402index health as telemetry only rather than the approval gate during provider intake
- document the updated intake workflow and note the future automation path

## What changed
- fetched all L402 services from `https://402index.io/api/v1/services` page by page
- grouped missing providers and recorded provider-level decisions in `src/registry/providers/`
- added one representative endpoint per approved-for-trial or deferred provider in `src/registry/services/`
- marked duplicate provider aliases explicitly to avoid re-review
- added caveats where representative service metadata still comes from scraper-derived directory text
- updated docs to make the intake rule explicit: 402index health is informational telemetry, not the decision gate

## Registry counts in this PR
- providers added: 63
  - approved-for-trial: 44
  - deferred: 4
  - rejected: 6
  - duplicate: 9
- representative services added: 48
  - approved-for-trial: 44
  - deferred: 4

## Verification
- `npm run build`
- independent review subagent pass after fixing duplicate handling and representative endpoint issues

## Notes
- this PR adds provider/service intake records only; it does not activate new landing pages yet
- representative service entries remain `activationStatus: not-started` and `landingPageStatus: coming-soon` until direct endpoint review or paid testing happens
