### PR TITLE
feat: add SEO foundation for staging and production cutover

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,9 +2,20 @@
 export interface Props {
   title: string;
   description: string;
+  robots?: string;
+  canonical?: string;
+  ogImage?: string;
+  schema?: Record<string, unknown> | Record<string, unknown>[];
 }
 
-const { title, description } = Astro.props;
+import { buildCanonicalUrl, buildRobotsDirective, truncateMetaDescription } from '../seo';
+
+const { title, description, robots, canonical, ogImage, schema } = Astro.props;
+const canonicalUrl = canonical ?? buildCanonicalUrl({ pathname: Astro.url.pathname, site: Astro.site });
+const robotsDirective = robots ?? buildRobotsDirective({ site: Astro.site });
+const metaDescription = truncateMetaDescription(description);
+const socialImage = ogImage ?? buildCanonicalUrl({ pathname: `${import.meta.env.BASE_URL}favicon.svg`, site: Astro.site });
+const schemaBlocks = schema ? (Array.isArray(schema) ? schema : [schema]) : [];
 ---
 
 <!doctype html>
@@ -12,9 +23,21 @@ const { title, description } = Astro.props;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content={description} />
+    <meta name="description" content={metaDescription} />
+    <meta name="robots" content={robotsDirective} />
     <meta name="generator" content={Astro.generator} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={metaDescription} />
+    {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
+    {socialImage && <meta property="og:image" content={socialImage} />}
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={metaDescription} />
+    {socialImage && <meta name="twitter:image" content={socialImage} />}
     <title>{title}</title>
+    {schemaBlocks.map((entry) => <script type="application/ld+json" set:html={JSON.stringify(entry)} />)}
     <style>
       :root {
         --bg: #0b1020;

--- a/src/pages/agents/[agent]/[slug].astro
+++ b/src/pages/agents/[agent]/[slug].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro';
 import ActionCta from '../../../components/ActionCta.astro';
 import IdentityLine from '../../../components/IdentityLine.astro';
 import { variants } from '../../../data/build-variants';
+import { buildPageSeo } from '../../../seo-rules';
 
 export function getStaticPaths() {
   return variants.map((variant) => ({
@@ -15,9 +16,71 @@ const { variant } = Astro.props;
 const title = variant.title;
 const description = variant.description;
 const relatedVariants = variants.filter((item) => item.agentKey === variant.agentKey && item.slug !== variant.slug).slice(0, 3);
+const seo = buildPageSeo({
+  pathname: Astro.url.pathname,
+  site: Astro.site,
+  pageType: 'service',
+  supportStatus: variant.supportStatus,
+});
+const ogImage =
+  variant.exampleOutput.kind === 'image'
+    ? new URL(variant.exampleOutput.imageSrc, Astro.site).toString()
+    : new URL(variant.providerLogoSrc, Astro.site).toString();
+const schema = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: new URL(import.meta.env.BASE_URL, Astro.site).toString(),
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: title,
+        item: seo.canonical,
+      },
+    ],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Service',
+    name: title,
+    description,
+    url: seo.canonical,
+    provider: {
+      '@type': 'Organization',
+      name: variant.providerName,
+    },
+    areaServed: 'Worldwide',
+    category: variant.category,
+    offers: {
+      '@type': 'Offer',
+      priceCurrency: 'USD',
+      description: variant.priceLabel,
+      availability: variant.supportStatus === 'supported' ? 'https://schema.org/InStock' : 'https://schema.org/PreOrder',
+      url: seo.canonical,
+    },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: variant.faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  },
+];
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} canonical={seo.canonical} robots={seo.robots} ogImage={ogImage} schema={schema}>
   <article class="page">
     <section class="hero panel">
       <div class="hero-main">

--- a/src/pages/coming-soon/[agent].astro
+++ b/src/pages/coming-soon/[agent].astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { agentsByKey } from '../../data/agents';
 import { variants } from '../../data/build-variants';
+import { buildPageSeo } from '../../seo-rules';
 
 export function getStaticPaths() {
   return Object.keys(agentsByKey).map((agent) => ({ params: { agent } }));
@@ -14,9 +15,17 @@ const supportedToday = agentVariants.filter((variant) => variant.supportStatus =
 const installHref = `${import.meta.env.BASE_URL}install/${agent}/`;
 const title = `More services for ${currentAgent?.name ?? 'your agent'} are coming soon`;
 const description = `Explore services available now for ${currentAgent?.name ?? 'your agent'} and install the Alby Payments Skill.`;
+const seo = buildPageSeo({ pathname: Astro.url.pathname, site: Astro.site, pageType: 'coming-soon' });
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: title,
+  description,
+  url: seo.canonical,
+};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} canonical={seo.canonical} robots={seo.robots} schema={schema}>
   <section class="panel page">
     <div class="hero-row">
       {currentAgent && <img class="agent-logo" src={currentAgent.logoSrc} alt={`${currentAgent.name} logo`} />}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,9 +2,11 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import IdentityLine from '../components/IdentityLine.astro';
 import { agents, homepageVariants, providers, serviceDefinitions } from '../data/build-variants';
+import { buildPageSeo, isServicePageIndexable } from '../seo-rules';
 
 const title = 'Pay-per-use Agent Services';
 const description = 'Find pay-per-use services for research, content, images, and documents that work with your agent.';
+const seo = buildPageSeo({ pathname: Astro.url.pathname, site: Astro.site, pageType: 'home' });
 
 const featuredVariants = homepageVariants.filter((variant) => variant.supportStatus === 'supported').slice(0, 3);
 const homepageStats = [
@@ -14,9 +16,26 @@ const homepageStats = [
   { value: String(homepageVariants.length), label: 'available options' },
 ];
 const categoryHighlights = [...new Set(homepageVariants.map((variant) => variant.category))].slice(0, 5);
+const indexedHomepageVariants = homepageVariants.filter((variant) => isServicePageIndexable(variant.supportStatus));
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: title,
+  description,
+  url: seo.canonical,
+  mainEntity: {
+    '@type': 'ItemList',
+    itemListElement: indexedHomepageVariants.slice(0, 24).map((variant, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: seo.canonical ? new URL(`${import.meta.env.BASE_URL}agents/${variant.agentKey}/${variant.slug}/`, Astro.site).toString() : undefined,
+      name: `${variant.agentName} · ${variant.providerName} · ${variant.serviceName}`,
+    })),
+  },
+};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} canonical={seo.canonical} robots={seo.robots} schema={schema}>
   <section class="hero panel">
     <div>
       <span class="eyebrow">Pay only for the services you use</span>

--- a/src/pages/install/[agent].astro
+++ b/src/pages/install/[agent].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import { agentsByKey } from '../../data/agents';
 import { installFlows } from '../../data/install-flows';
 import { variants } from '../../data/build-variants';
+import { buildPageSeo } from '../../seo-rules';
 
 export function getStaticPaths() {
   return Object.keys(agentsByKey).map((agent) => ({ params: { agent } }));
@@ -15,9 +16,17 @@ const agentVariants = variants.filter((variant) => variant.agentKey === agent);
 const supportedToday = agentVariants.filter((variant) => variant.supportStatus === 'supported');
 const title = `Install the Alby Payments Skill for ${currentAgent?.name ?? 'your agent'}`;
 const description = `Install the Alby Payments Skill for ${currentAgent?.name ?? 'your agent'} and unlock supported services.`;
+const seo = buildPageSeo({ pathname: Astro.url.pathname, site: Astro.site, pageType: 'install' });
+const schema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: title,
+  description,
+  url: seo.canonical,
+};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} canonical={seo.canonical} robots={seo.robots} schema={schema}>
   <section class="panel install-page">
     <div class="hero-row">
       {currentAgent && <img class="agent-logo" src={currentAgent.logoSrc} alt={`${currentAgent.name} logo`} />}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,25 @@
+import { getIndexableRouteEntries } from '../seo-rules';
+import { isTemporarySeoHost } from '../seo';
+
+export function GET({ site }: { site: URL | undefined }) {
+  const indexableEntries = getIndexableRouteEntries(site);
+  const shouldDisallow = isTemporarySeoHost(site) || indexableEntries.length === 0;
+  const lines = [
+    'User-agent: *',
+    shouldDisallow ? 'Disallow: /' : 'Allow: /',
+  ];
+
+  if (!shouldDisallow) {
+    const sitemapUrl = site ? new URL(`${import.meta.env.BASE_URL}sitemap.xml`, site).toString() : `${import.meta.env.BASE_URL}sitemap.xml`;
+    lines.push(`Sitemap: ${sitemapUrl}`);
+  }
+
+  return new Response(
+    [...lines, ''].join('\n'),
+    {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+      },
+    },
+  );
+}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,24 @@
+import { getIndexableRouteEntries } from '../seo-rules';
+import { xmlEscape } from '../seo';
+
+export function GET({ site }: { site: URL | undefined }) {
+  const entries = getIndexableRouteEntries(site);
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries
+  .map(
+    (entry) => `  <url>
+    <loc>${xmlEscape(entry.url)}</loc>
+    <changefreq>${entry.changefreq}</changefreq>
+    <priority>${entry.priority}</priority>
+  </url>`,
+  )
+  .join('\n')}
+</urlset>`;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+}

--- a/src/seo-rules.ts
+++ b/src/seo-rules.ts
@@ -1,0 +1,65 @@
+import { buildCanonicalUrl, buildRobotsDirective, isTemporarySeoHost } from './seo';
+import { variants } from './data/build-variants';
+
+export const isServicePageIndexable = (supportStatus: 'supported' | 'coming-soon') => supportStatus === 'supported';
+
+export const buildPageSeo = ({
+  pathname,
+  site,
+  pageType,
+  supportStatus,
+}: {
+  pathname: string;
+  site: URL | string | undefined;
+  pageType: 'home' | 'service' | 'install' | 'coming-soon';
+  supportStatus?: 'supported' | 'coming-soon';
+}) => {
+  const shouldNoindex =
+    pageType === 'install' ||
+    pageType === 'coming-soon' ||
+    (pageType === 'service' && !isServicePageIndexable(supportStatus ?? 'coming-soon'));
+
+  return {
+    canonical: buildCanonicalUrl({ pathname, site }),
+    robots: buildRobotsDirective({ site, noindex: shouldNoindex }),
+    noindex: shouldNoindex || isTemporarySeoHost(site),
+  };
+};
+
+export const getIndexableRouteEntries = (site: URL | string | undefined) => {
+  if (isTemporarySeoHost(site)) {
+    return [];
+  }
+
+  const supportedVariants = variants.filter((variant) => isServicePageIndexable(variant.supportStatus));
+  const homepageCanonical = buildCanonicalUrl({ pathname: import.meta.env.BASE_URL, site });
+
+  return [
+    homepageCanonical
+      ? {
+          url: homepageCanonical,
+          changefreq: 'weekly',
+          priority: '1.0',
+        }
+      : null,
+    ...supportedVariants.map((variant) => {
+      const pathname = `${import.meta.env.BASE_URL}agents/${variant.agentKey}/${variant.slug}/`;
+      const seo = buildPageSeo({
+        pathname,
+        site,
+        pageType: 'service',
+        supportStatus: variant.supportStatus,
+      });
+
+      if (!seo.canonical || !isServicePageIndexable(variant.supportStatus)) {
+        return null;
+      }
+
+      return {
+        url: seo.canonical,
+        changefreq: 'weekly',
+        priority: '0.8',
+      };
+    }),
+  ].filter((entry): entry is { url: string; changefreq: string; priority: string } => Boolean(entry));
+};

--- a/src/seo.ts
+++ b/src/seo.ts
@@ -1,0 +1,70 @@
+const temporarySeoHostnames = new Set(['hermes-alby.github.io']);
+
+export const normalizeSiteUrl = (site: URL | string | undefined) => {
+  if (!site) {
+    return undefined;
+  }
+
+  return typeof site === 'string' ? new URL(site) : site;
+};
+
+export const isTemporarySeoHost = (site: URL | string | undefined) => {
+  const normalizedSite = normalizeSiteUrl(site);
+  return normalizedSite ? temporarySeoHostnames.has(normalizedSite.hostname) : false;
+};
+
+export const buildCanonicalUrl = ({
+  pathname,
+  site,
+}: {
+  pathname: string;
+  site: URL | string | undefined;
+}) => {
+  const normalizedSite = normalizeSiteUrl(site);
+
+  if (!normalizedSite) {
+    return undefined;
+  }
+
+  return new URL(pathname, normalizedSite).toString();
+};
+
+export const buildRobotsDirective = ({
+  site,
+  noindex = false,
+  nofollow = false,
+}: {
+  site: URL | string | undefined;
+  noindex?: boolean;
+  nofollow?: boolean;
+}) => {
+  const shouldNoindex = noindex || isTemporarySeoHost(site);
+
+  return `${shouldNoindex ? 'noindex' : 'index'},${nofollow ? 'nofollow' : 'follow'}`;
+};
+
+export const truncateMetaDescription = (text: string, maxLength = 160) => {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const candidate = text.slice(0, maxLength + 1);
+  const punctuationIndex = Math.max(candidate.lastIndexOf('. '), candidate.lastIndexOf('; '));
+
+  if (punctuationIndex >= 110) {
+    return candidate.slice(0, punctuationIndex + 1).trim();
+  }
+
+  const breakIndex = candidate.lastIndexOf(' ');
+  const truncated = (breakIndex >= 110 ? candidate.slice(0, breakIndex) : candidate.slice(0, maxLength)).trim();
+
+  return `${truncated.replace(/[.,;:!?\-\s]+$/u, '')}…`;
+};
+
+export const xmlEscape = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');


### PR DESCRIPTION
## Summary
- add a reusable SEO metadata layer for canonical, robots, OG/Twitter, and JSON-LD tags
- add sitemap and robots endpoints with staging-safe behavior for the temporary GitHub Pages host
- mark install and coming-soon pages as noindex, and define supported service pages as the intended future indexable set

## What changed
- extended `BaseLayout` to emit:
  - canonical tags
  - robots meta tags
  - OG/Twitter metadata
  - JSON-LD blocks
- added SEO helpers in:
  - `src/seo.ts`
  - `src/seo-rules.ts`
- wired homepage, service pages, install pages, and coming-soon pages into the new SEO layer
- added:
  - `src/pages/robots.txt.ts`
  - `src/pages/sitemap.xml.ts`
- treated the current `github.io` host as temporary staging:
  - pages emit `noindex,follow`
  - `robots.txt` disallows crawling
  - `sitemap.xml` is empty on the temporary host

## Verification
- `npm run build`
- verified generated output now includes canonical, robots, OG/Twitter, and JSON-LD tags
- verified staging behavior in built output:
  - all pages emit `noindex,follow`
  - `dist/robots.txt` returns `Disallow: /`
  - `dist/sitemap.xml` is empty on the temporary host
- independent reviewer subagent pass: ✅

## Follow-up
- Production-domain cutover and launch checklist: #12
